### PR TITLE
Feature/add unique classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .eslintignore
 .eslintrc
 .sass-lint.yml
+/sftp-config.json

--- a/includes/library.php
+++ b/includes/library.php
@@ -786,9 +786,10 @@ function bu_navigation_list_section($parent_id, $pages_by_parent, $args = '')
 	$defaults = array(
 		'depth' => 1,
 		'container_tag' => 'ul',
+		'container_class' => NULL,
 		'item_tag' => 'li',
 		'section_ids' => NULL
-		);
+	);
 
 	$r = wp_parse_args($args, $defaults);
 
@@ -800,7 +801,11 @@ function bu_navigation_list_section($parent_id, $pages_by_parent, $args = '')
 
 		if ((is_array($children)) && (count($children) > 0))
 		{
-			$html .= sprintf("\n<%s>\n", $r['container_tag']);;
+			if ( $r['container_class'] ) {
+				$html .= sprintf( '<%s class="%s">', $r['container_tag'], $r['container_class'] );;
+			} else {
+				$html .= sprintf( '<%s>', $r['container_tag'] );;
+			}
 
 			foreach ($children as $page)
 			{
@@ -808,12 +813,19 @@ function bu_navigation_list_section($parent_id, $pages_by_parent, $args = '')
 				$sargs['depth']++;
 
 				$child_html = bu_navigation_list_section($page->ID, $pages_by_parent, $sargs);
-				$html .= bu_navigation_format_page($page, array(
+
+				$pargs = array(
 					'html' => $child_html,
 					'depth' => $r['depth'],
 					'item_tag' => $r['item_tag'],
-					'section_ids' => $r['section_ids']
-					));
+					'section_ids' => $r['section_ids'],
+				);
+
+				if ( $r['container_class'] ) {
+					$pargs['item_class'] = $r['container_class'] . '-item';
+				}
+
+				$html .= bu_navigation_format_page( $page, $pargs );
 			}
 
 			$html .= sprintf("\n</%s>\n", $r['container_tag']);
@@ -927,10 +939,11 @@ function bu_navigation_list_pages( $args = '' ) {
 
 		$sargs = array(
 			'container_tag' => $r['container_tag'],
+			'container_class' => $r['container_class'],
 			'item_tag' => $r['item_tag'],
 			'depth' => 2,
 			'section_ids' => $section_ids
-			);
+		);
 
 		$page_position = 1;
 		$number_siblings = count( $pages_by_parent[$section] );
@@ -1036,6 +1049,7 @@ function bu_navigation_display_primary( $args = '' ) {
 		// Section arguments
 		$sargs = array(
 			'container_tag' => $r['container_tag'],
+			'container_class' => $r['container_class'] . '-section',
 			'item_tag' => $r['item_tag'],
 			'depth' => 2
 			);

--- a/includes/library.php
+++ b/includes/library.php
@@ -616,6 +616,7 @@ function bu_navigation_format_page( $page, $args = '' ) {
 	$defaults = array(
 		'item_tag' => 'li',
 		'item_id' => null,
+		'item_class' => null,
 		'html' => '',
 		'depth' => null,
 		'position' => null,
@@ -664,6 +665,10 @@ function bu_navigation_format_page( $page, $args = '' ) {
 
 	if ( is_array( $r['section_ids'] ) && in_array( $page->ID, $r['section_ids'] ) )
 		array_push( $item_classes, 'has_children' );
+
+	if ( $r['item_class'] ) {
+		array_push( $item_classes, $r['item_class'] );
+	}
 
 	if ( is_numeric( $r['position'] ) && is_numeric( $r['siblings'] ) ) {
 		if ( $r['position'] == 1 )
@@ -1047,12 +1052,22 @@ function bu_navigation_display_primary( $args = '' ) {
 			if ( $r['dive'] )
 				$child_html = bu_navigation_list_section( $page->ID, $pages_by_parent, $sargs );
 
+			$pargs = array(
+				'html' => $child_html,
+				'depth' => 1,
+				'item_tag' => $r['item_tag']
+			);
+
+			if ( $r['container_class'] ) {
+				$pargs['item_class'] = $r['container_id'] . '-item';
+			}
+
 			// Display formatted page (optionally with post name as ID)
 			if ( $r['identify_top'] ) {
-				$html .= bu_navigation_format_page( $page, array( 'html' => $child_html, 'depth' => 1, 'item_tag' => $r['item_tag'], 'item_id' => $page->post_name ) );
-			} else {
-				$html .= bu_navigation_format_page( $page, array( 'html' => $child_html, 'depth' => 1, 'item_tag' => $r['item_tag'] ) );
+				$pargs['item_id'] = $page->post_name;
 			}
+
+			$html .= bu_navigation_format_page( $page, $pargs );
 
 			$nItems++;
 

--- a/includes/library.php
+++ b/includes/library.php
@@ -803,9 +803,9 @@ function bu_navigation_list_section($parent_id, $pages_by_parent, $args = '')
 		if ((is_array($children)) && (count($children) > 0))
 		{
 			if ( $r['container_class'] ) {
-				$html .= sprintf( '<%s class="%s">', $r['container_tag'], $r['container_class'] );;
+				$html .= sprintf( "\n<%s class='%s'>\n", $r['container_tag'], $r['container_class'] );
 			} else {
-				$html .= sprintf( '<%s>', $r['container_tag'] );;
+				$html .= sprintf( "\n<%s>\n", $r['container_tag'] );
 			}
 
 			foreach ($children as $page)

--- a/includes/library.php
+++ b/includes/library.php
@@ -966,9 +966,9 @@ function bu_navigation_list_pages( $args = '' ) {
 				'section_ids' => $section_ids
 			);
 
-			if ( $r['container_class'] ) {
-				$pargs['item_class'] = $r['container_class'] . '-item';
-				$pargs['anchor_class'] = $r['container_class'] . '-link';
+			if ( $r['container_id'] ) {
+				$pargs['item_class'] = $r['container_id'] . '-item';
+				$pargs['anchor_class'] = $r['container_id'] . '-link';
 			}
 
 			$html .= bu_navigation_format_page($page, $pargs);
@@ -1085,9 +1085,9 @@ function bu_navigation_display_primary( $args = '' ) {
 				'item_tag' => $r['item_tag']
 			);
 
-			if ( $r['container_class'] ) {
-				$pargs['item_class'] = $r['container_class'] . '-item';
-				$pargs['anchor_class'] = $r['container_class'] . '-link';
+			if ( $r['container_id'] ) {
+				$pargs['item_class'] = $r['container_id'] . '-item';
+				$pargs['anchor_class'] = $r['container_id'] . '-link';
 			}
 
 			// Display formatted page (optionally with post name as ID)

--- a/includes/library.php
+++ b/includes/library.php
@@ -803,7 +803,7 @@ function bu_navigation_list_section($parent_id, $pages_by_parent, $args = '')
 		if ((is_array($children)) && (count($children) > 0))
 		{
 			if ( $r['container_class'] ) {
-				$html .= sprintf( "\n<%s class='%s'>\n", $r['container_tag'], $r['container_class'] );
+				$html .= "\n" . sprintf( '<%s class="%s">', $r['container_tag'], $r['container_class'] ) . "\n";
 			} else {
 				$html .= sprintf( "\n<%s>\n", $r['container_tag'] );
 			}

--- a/includes/library.php
+++ b/includes/library.php
@@ -941,11 +941,14 @@ function bu_navigation_list_pages( $args = '' ) {
 
 		$sargs = array(
 			'container_tag' => $r['container_tag'],
-			'container_class' => $r['container_class'],
 			'item_tag' => $r['item_tag'],
 			'depth' => 2,
 			'section_ids' => $section_ids
 		);
+
+		if ( $r['container_id'] ) {
+			$sargs['container_class'] = $r['container_id'] . '-section';
+		}
 
 		$page_position = 1;
 		$number_siblings = count( $pages_by_parent[$section] );
@@ -1056,10 +1059,13 @@ function bu_navigation_display_primary( $args = '' ) {
 		// Section arguments
 		$sargs = array(
 			'container_tag' => $r['container_tag'],
-			'container_class' => $r['container_class'] . '-section',
 			'item_tag' => $r['item_tag'],
 			'depth' => 2
 			);
+
+		if ( $r['container_id'] ) {
+			$sargs['container_class'] = $r['container_id'] . '-section';
+		}
 
 		foreach ( $top_level_pages as $page ) {
 

--- a/includes/library.php
+++ b/includes/library.php
@@ -637,8 +637,9 @@ function bu_navigation_format_page( $page, $args = '' ) {
 	$href = $page->url;
 	$anchor_class = $r['anchor_class'];
 
-	if ( is_numeric( $r['depth'] ) )
+	if ( is_numeric( $r['depth'] ) ) {
 		$anchor_class .= sprintf( ' level_%d', intval( $r['depth'] ) );
+	}
 
 	$attrs = array(
 		'class' => trim( $anchor_class ),
@@ -823,6 +824,7 @@ function bu_navigation_list_section($parent_id, $pages_by_parent, $args = '')
 
 				if ( $r['container_class'] ) {
 					$pargs['item_class'] = $r['container_class'] . '-item';
+					$pargs['anchor_class'] = $r['container_class'] . '-link';
 				}
 
 				$html .= bu_navigation_format_page( $page, $pargs );
@@ -961,6 +963,11 @@ function bu_navigation_list_pages( $args = '' ) {
 				'section_ids' => $section_ids
 			);
 
+			if ( $r['container_class'] ) {
+				$pargs['item_class'] = $r['container_class'] . '-item';
+				$pargs['anchor_class'] = $r['container_class'] . '-link';
+			}
+
 			$html .= bu_navigation_format_page($page, $pargs);
 
 			$page_position++;
@@ -1073,7 +1080,8 @@ function bu_navigation_display_primary( $args = '' ) {
 			);
 
 			if ( $r['container_class'] ) {
-				$pargs['item_class'] = $r['container_id'] . '-item';
+				$pargs['item_class'] = $r['container_class'] . '-item';
+				$pargs['anchor_class'] = $r['container_class'] . '-link';
 			}
 
 			// Display formatted page (optionally with post name as ID)

--- a/tests/phpunit/test-library.php
+++ b/tests/phpunit/test-library.php
@@ -1440,38 +1440,38 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		*/
 
 		$list_pages_container_id_expected = '<ul  id="test_container_id">' . "\n" .
-			'<li class="page_item page-item-' . $parent . ' first_item">' . "\n" .
-			'<a class="level_1" href="' . get_permalink( $parent ) . '">Parent Page</a>' . "\n \n" .
-			"<ul>\n" .
-			'<li class="page_item page-item-' . $child . '">' . "\n" .
-			'<a class="level_2" href="' . get_permalink( $child ) . '">Child Page</a>' . "\n \n" .
-			"<ul>\n" .
-			'<li class="page_item page-item-' . $grandchild_one . '">' . "\n" .
-			'<a class="level_3" href="' . get_permalink( $grandchild_one ) . '">Grand Child Page 1</a>' . "\n \n" .
-			"<ul>\n" .
-			'<li class="page_item page-item-' . $greatgrandchild . '">' . "\n" .
-			'<a class="level_4" href="' . get_permalink( $greatgrandchild ) . '">Great Grand Child</a>' . "\n" .
+			'<li class="page_item page-item-' . $parent . ' test_container_id-item first_item">' . "\n" .
+			'<a class="test_container_id-link level_1" href="' . get_permalink( $parent ) . '">Parent Page</a>' . "\n \n" .
+			'<ul class="test_container_id-section">' . "\n" .
+			'<li class="page_item page-item-' . $child . ' test_container_id-section-item">' . "\n" .
+			'<a class="test_container_id-section-link level_2" href="' . get_permalink( $child ) . '">Child Page</a>' . "\n \n" .
+			'<ul class="test_container_id-section">' . "\n" .
+			'<li class="page_item page-item-' . $grandchild_one . ' test_container_id-section-item">' . "\n" .
+			'<a class="test_container_id-section-link level_3" href="' . get_permalink( $grandchild_one ) . '">Grand Child Page 1</a>' . "\n \n" .
+			'<ul class="test_container_id-section">' . "\n" .
+			'<li class="page_item page-item-' . $greatgrandchild . ' test_container_id-section-item">' . "\n" .
+			'<a class="test_container_id-section-link level_4" href="' . get_permalink( $greatgrandchild ) . '">Great Grand Child</a>' . "\n" .
 			" </li>\n\n" .
 			"</ul>\n" .
 			"</li>\n" .
-			'<li class="page_item page-item-' . $grandchild_two . '">' . "\n".
-			'<a class="level_3" href="' . get_permalink( $grandchild_two ) . '">Grand Child Page 2</a>' . "\n" .
+			'<li class="page_item page-item-' . $grandchild_two . ' test_container_id-section-item">' . "\n".
+			'<a class="test_container_id-section-link level_3" href="' . get_permalink( $grandchild_two ) . '">Grand Child Page 2</a>' . "\n" .
 			" </li>\n\n" .
 			"</ul>\n" .
 			"</li>\n\n" .
 			"</ul>\n" .
 			"</li>\n" .
-			'<li class="page_item page-item-' . $parent_two . '">' . "\n" .
-			'<a class="level_1" href="' . get_permalink( $parent_two ) . '">Parent Page Two</a>' . "\n" .
+			'<li class="page_item page-item-' . $parent_two . ' test_container_id-item">' . "\n" .
+			'<a class="test_container_id-link level_1" href="' . get_permalink( $parent_two ) . '">Parent Page Two</a>' . "\n" .
 			" </li>\n" .
-			'<li class="page_item page-item-' . $edit . '">' . "\n" .
-			'<a class="level_1" href="' . get_permalink( $edit ) . '">Edit and Delete Me</a>' . "\n" .
+			'<li class="page_item page-item-' . $edit . ' test_container_id-item">' . "\n" .
+			'<a class="test_container_id-link level_1" href="' . get_permalink( $edit ) . '">Edit and Delete Me</a>' . "\n" .
 			" </li>\n" .
-			'<li class="page_item page-item-' . $google . '">' . "\n" .
-			'<a class="level_1" href="' . get_permalink( $google ) . '" target="_blank">Google</a>' . "\n" .
+			'<li class="page_item page-item-' . $google . ' test_container_id-item">' . "\n" .
+			'<a class="test_container_id-link level_1" href="' . get_permalink( $google ) . '" target="_blank">Google</a>' . "\n" .
 			" </li>\n" .
-			'<li class="page_item page-item-' . $last_page . ' last_item">' . "\n" .
-			'<a class="level_1" href="' . get_permalink( $last_page ) . '">Last Page</a>' . "\n" .
+			'<li class="page_item page-item-' . $last_page . ' test_container_id-item last_item">' . "\n" .
+			'<a class="test_container_id-link level_1" href="' . get_permalink( $last_page ) . '">Last Page</a>' . "\n" .
 			" </li>\n" .
 			"</ul>\n";
 

--- a/tests/phpunit/test-plugin.php
+++ b/tests/phpunit/test-plugin.php
@@ -102,7 +102,7 @@ class Test_BU_Navigation_Plugin extends BU_Navigation_UnitTestCase {
 		ob_end_clean();
 
 		$this->assertRegExp('/<h2.+Page 1<\/a>/i', $widget);
-		$this->assertRegExp('/class="level_1".+Subpage 1-A<\/a>/is', $widget);
+		$this->assertRegExp('/class="contentnavlist-link level_1".+Subpage 1-A<\/a>/is', $widget);
 
 		// load perspective of page page1_A
 		$post = get_post( $page1_A );
@@ -121,6 +121,6 @@ class Test_BU_Navigation_Plugin extends BU_Navigation_UnitTestCase {
 		ob_end_clean();
 
 		$this->assertRegExp('/<h2.+Page 1<\/a>/i', $widget);
-		$this->assertRegExp('/class="level_1".+Subpage 1-A<\/a>/is', $widget);
+		$this->assertRegExp('/class="contentnavlist-link level_1".+Subpage 1-A<\/a>/is', $widget);
 	}
 }


### PR DESCRIPTION
In an effort to reduce our CSS specificity in Responsive, I'd like to add some unique classes to the section, links, and items in BU Navigation's HTML. This pull request would accomplish that by automatically adding a new class to page items, sections, and page items within sections if a container ID is defined. The idea is to have unique classes on each of these to help with cleaner CSS targeting, especially in the primary navigation and content navigation widgets - which is why it makes sense to generate this set of classes based off the ID.

I think these classes are safe to add - it is very unlikely anyone is using these classes for anything else. Here's some examples of classes generated with this set of changes:

**In Primary Navigation in Responsive:**

- primary-nav-menu-item
- primary-nav-menu-link
- primary-nav-menu-section
- primary-nav-menu-section-item
- primary-nav-menu-section-link

**In the Content Navigation widget:**

- contentnavlist-item
- contentnavlist-link
- contentnavlist-section
- contentnavlist-section-item
- contentnavlist-section-link

You can see this in action on my sandbox: http://bun.cms-devl.bu.edu/responsi/basic-html/

Would love thoughts/review when you guys have a chance!