### PR TITLE
Allow list section defaults to be filtered, account for container class

### DIFF
--- a/includes/library.php
+++ b/includes/library.php
@@ -785,7 +785,7 @@ function bu_navigation_list_section($parent_id, $pages_by_parent, $args = '')
 		'section_ids' => NULL
 		);
 
-	$r = wp_parse_args($args, $defaults);
+	$r = wp_parse_args( $args, apply_filters( 'bu_filter_list_section_defaults', $defaults ));
 
 	$html = '';
 

--- a/includes/library.php
+++ b/includes/library.php
@@ -781,6 +781,7 @@ function bu_navigation_list_section($parent_id, $pages_by_parent, $args = '')
 	$defaults = array(
 		'depth' => 1,
 		'container_tag' => 'ul',
+		'container_class' => NULL,
 		'item_tag' => 'li',
 		'section_ids' => NULL
 		);
@@ -795,7 +796,13 @@ function bu_navigation_list_section($parent_id, $pages_by_parent, $args = '')
 
 		if ((is_array($children)) && (count($children) > 0))
 		{
-			$html .= sprintf("\n<%s>\n", $r['container_tag']);;
+			$html .= sprintf("\n<%s", $r['container_tag']);;
+
+			if ( $r['container_class'] ) {
+				$html .= ' class="' . esc_attr( $r['container_class'] ) . '"';
+			}
+
+			$html .= ">\n";
 
 			foreach ($children as $page)
 			{

--- a/includes/library.php
+++ b/includes/library.php
@@ -786,7 +786,7 @@ function bu_navigation_list_section($parent_id, $pages_by_parent, $args = '')
 		'section_ids' => NULL
 		);
 
-	$r = wp_parse_args( $args, apply_filters( 'bu_filter_list_section_defaults', $defaults ));
+	$r = wp_parse_args( $args, apply_filters( 'bu_filter_list_section_defaults', $defaults ) );
 
 	$html = '';
 


### PR DESCRIPTION
We're converting styles and JavaScript that we've previously used with a standard WP nav menu and `sub-menu` is used by WordPress for child `<ul>` elements by default. This change makes it possible to filter the container class for sections as it is output.

Thanks for BU Navigation, we love it at WSU. 🍻 