### PR TITLE
Add support for Post Type Templates in WordPress 4.7

### DIFF
--- a/admin/post.php
+++ b/admin/post.php
@@ -128,7 +128,7 @@ class BU_Navigation_Admin_Post {
 		// Remove built in page attributes meta box
 		remove_meta_box('pageparentdiv', $post_type, 'side');
 
-		$templates = get_page_templates( $post_type );
+		$templates = get_page_templates( $post );
 
 		if ( is_array( $templates ) && ( count( $templates ) > 0 ) ) {
 			add_meta_box(

--- a/admin/post.php
+++ b/admin/post.php
@@ -130,7 +130,7 @@ class BU_Navigation_Admin_Post {
 
 		$templates = get_page_templates( $post_type );
 
-		if ( 'page' === $post_type && is_array( $templates ) && ( count( $templates ) > 0 ) ) {
+		if ( is_array( $templates ) && ( count( $templates ) > 0 ) ) {
 			add_meta_box(
 				'bupagetemplatediv',
 				sprintf( __( "%s Template", 'bu-navigation'  ), $post_type_object->labels->singular_name ),

--- a/admin/post.php
+++ b/admin/post.php
@@ -128,7 +128,7 @@ class BU_Navigation_Admin_Post {
 		// Remove built in page attributes meta box
 		remove_meta_box('pageparentdiv', $post_type, 'side');
 
-		$templates = get_page_templates();
+		$templates = get_page_templates( $post_type );
 
 		if ( 'page' === $post_type && is_array( $templates ) && ( count( $templates ) > 0 ) ) {
 			add_meta_box(
@@ -198,6 +198,8 @@ class BU_Navigation_Admin_Post {
 	 * Since we replace the standard "Page Attributes" meta box with our own,
 	 * we relocate the "Template" dropdown that usually appears there to its
 	 * own custom meta box
+	 *
+	 * @param WP_Post $post Current post object.
 	 */
 	public function display_custom_template( $post ) {
 

--- a/templates/metabox-custom-template.php
+++ b/templates/metabox-custom-template.php
@@ -2,6 +2,6 @@
 <label class="screen-reader-text" for="page_template"><?php printf( __( '%s Template', 'bu-navigation' ), $post_type->labels->singular_name ); ?></label>
 <select name="page_template" id="page_template">
 	<option value='default'><?php _e( 'Default Template', 'bu-navigation' ); ?></option>
-	<?php page_template_dropdown( $current_template ); ?>
+	<?php page_template_dropdown( $current_template, $post_type ); ?>
 </select>
 <p><?php printf( __( 'Some themes have custom templates you can use for certain %s that might have additional features or custom layouts.', 'bu-navigation' ), strtolower( $post_type->labels->name ) ); ?></p>


### PR DESCRIPTION
In WordPress 4.7, support was added for page templates in all post types. This PR adds better support this feature.

See: https://make.wordpress.org/core/2016/11/03/post-type-templates-in-4-7/