### PR TITLE
Avoid conflicts when editing page order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: php
 sudo: false
 
 php:
-    - 5.4
-    - 5.5
     - 5.6
     - 7.0
     - 7.1

--- a/admin/manager.php
+++ b/admin/manager.php
@@ -260,6 +260,7 @@ class BU_Navigation_Admin_Manager {
 	public function get_notice_by_code( $type, $code ) {
 
 		$user_markup = '<strong>%s</strong>';
+		$post_type = get_post_type_object( $this->post_type );
 
 		$notices = array(
 			'message' => array(
@@ -270,7 +271,7 @@ class BU_Navigation_Admin_Manager {
 				0 => '',
 				1 => __( 'Errors occurred while saving your navigation changes.', 'bu-navigation' ),
 				2 => sprintf( __( "Warning: %s is currently editing this site's navigation.", 'bu-navigation' ), $user_markup ),
-				3 => __( "Error: Another user made changes to this site's navigation menu. Please retry.", 'bu-navigation' ),
+				3 => sprintf( __( '%s order has been modified by someone else. Please retry.', 'bu-navigation' ),  $post_type->labels->singular_name),
 			),
 		);
 

--- a/admin/manager.php
+++ b/admin/manager.php
@@ -145,6 +145,9 @@ class BU_Navigation_Admin_Manager {
 
 	}
 
+	/**	
+	 * Get fully configured instance of BU_Navigation_Tree_View	
+	 */
 	public function get_navigation_tree() {
 		// Strings for localization
 		$nav_menu_label = __( 'Appearance > Primary Navigation', 'bu-navigation' );
@@ -175,7 +178,7 @@ class BU_Navigation_Admin_Manager {
 			'lazyLoad' => true,
 			'showCounts' => true,
 		);
-		
+
 		return new BU_Navigation_Tree_View( 'bu_navman', array_merge( $script_context, $strings ) );
 	}
 

--- a/admin/manager.php
+++ b/admin/manager.php
@@ -126,37 +126,8 @@ class BU_Navigation_Admin_Manager {
 			wp_register_script( 'bu-jquery-validate', $vendor_url . '/jquery.validate' . $suffix . '.js', array( 'jquery' ), '1.8.1', true );
 			wp_register_script( 'bu-navman', $scripts_url . '/manage' . $suffix . '.js', array( 'bu-navigation', 'jquery-ui-dialog', 'bu-jquery-validate' ), BU_Navigation_Plugin::VERSION, true );
 
-			// Strings for localization
-			$nav_menu_label = __( 'Appearance > Primary Navigation', 'bu-navigation' );
-			$strings = array(
-				'optionsLabel' => __( 'options', 'bu-navigation' ),
-				'optionsEditLabel' => __( 'Edit', 'bu-navigation' ),
-				'optionsViewLabel' => __( 'View', 'bu-navigation' ),
-				'optionsDeleteLabel' => __( 'Delete', 'bu-navigation' ),
-				'optionsTrashLabel' => __( 'Move to Trash', 'bu-navigation' ),
-				'addLinkDialogTitle' => __( 'Add a Link', 'bu-navigation' ),
-				'editLinkDialogTitle' => __( 'Edit Link', 'bu-navigation' ),
-				'cancelLinkBtn' => __( 'Cancel', 'bu-navigation' ),
-				'confirmLinkBtn' => __( 'Ok', 'bu-navigation' ),
-				'noTopLevelNotice' => __( 'You are not allowed to create top level published content.', 'bu-navigation' ),
-				'noLinksNotice' => __( 'You are not allowed to add links', 'bu-navigation' ),
-				'createLinkNotice' => __( 'Select a page that you can edit and click "Add a Link" to create a new link below the selected page.', 'bu-navigation' ),
-				'allowTopNotice' => sprintf( __( 'Site administrators can change this behavior by visiting %s and enabling the "Allow Top-Level Pages" setting.', 'bu-navigation' ), $nav_menu_label ),
-				'noChildLinkNotice' => __( 'Links are not permitted to have children.', 'bu-navigation' ),
-				'unloadWarning' => __( 'You have made changes to your navigation that have not yet been saved.', 'bu-navigation' ),
-				'saveNotice' => __( 'Saving navigation changes...', 'bu-navigation' ),
-				);
-
-			// Setup dynamic script context for manage.js
-			$script_context = array(
-				'postTypes' => $this->post_type,
-				'postStatuses' => array( 'publish', 'private' ),
-				'nodePrefix' => 'nm',
-				'lazyLoad' => true,
-				'showCounts' => true,
-				);
 			// Navigation tree view will handle actual enqueuing of our script
-			$treeview = new BU_Navigation_Tree_View( 'bu_navman', array_merge( $script_context, $strings ) );
+			$treeview = $this->get_navigation_tree();
 			$treeview->enqueue_script( 'bu-navman' );
 
 			// Register custom jQuery UI stylesheet if it isn't already
@@ -172,6 +143,43 @@ class BU_Navigation_Admin_Manager {
 
 		}
 
+	}
+
+	/**
+	 * Get fully configured instance of BU_Navigation_Tree_View
+	 */
+	public function get_navigation_tree() {
+		// Strings for localization
+		$nav_menu_label = __( 'Appearance > Primary Navigation', 'bu-navigation' );
+		$strings = array(
+			'optionsLabel' => __( 'options', 'bu-navigation' ),
+			'optionsEditLabel' => __( 'Edit', 'bu-navigation' ),
+			'optionsViewLabel' => __( 'View', 'bu-navigation' ),
+			'optionsDeleteLabel' => __( 'Delete', 'bu-navigation' ),
+			'optionsTrashLabel' => __( 'Move to Trash', 'bu-navigation' ),
+			'addLinkDialogTitle' => __( 'Add a Link', 'bu-navigation' ),
+			'editLinkDialogTitle' => __( 'Edit Link', 'bu-navigation' ),
+			'cancelLinkBtn' => __( 'Cancel', 'bu-navigation' ),
+			'confirmLinkBtn' => __( 'Ok', 'bu-navigation' ),
+			'noTopLevelNotice' => __( 'You are not allowed to create top level published content.', 'bu-navigation' ),
+			'noLinksNotice' => __( 'You are not allowed to add links', 'bu-navigation' ),
+			'createLinkNotice' => __( 'Select a page that you can edit and click "Add a Link" to create a new link below the selected page.', 'bu-navigation' ),
+			'allowTopNotice' => sprintf( __( 'Site administrators can change this behavior by visiting %s and enabling the "Allow Top-Level Pages" setting.', 'bu-navigation' ), $nav_menu_label ),
+			'noChildLinkNotice' => __( 'Links are not permitted to have children.', 'bu-navigation' ),
+			'unloadWarning' => __( 'You have made changes to your navigation that have not yet been saved.', 'bu-navigation' ),
+			'saveNotice' => __( 'Saving navigation changes...', 'bu-navigation' ),
+		);
+
+		// Setup dynamic script context for manage.js
+		$script_context = array(
+			'postTypes' => $this->post_type,
+			'postStatuses' => array( 'publish', 'private' ),
+			'nodePrefix' => 'nm',
+			'lazyLoad' => true,
+			'showCounts' => true,
+		);
+
+		return new BU_Navigation_Tree_View( 'bu_navman', array_merge( $script_context, $strings ) );
 	}
 
 	/**

--- a/admin/manager.php
+++ b/admin/manager.php
@@ -329,7 +329,7 @@ class BU_Navigation_Admin_Manager {
 		$notices = $this->get_notice_list();
 		$include_links = $this->plugin->supports( 'links' ) && 'page' == $this->post_type;
 		$disable_add_link = ! $this->can_publish_top_level( $this->post_type );
-
+		$tree = $this->get_navigation_tree();
 		// Render interface
 		include( BU_NAV_PLUGIN_DIR . '/templates/edit-order.php' );
 

--- a/includes/class-tree-view.php
+++ b/includes/class-tree-view.php
@@ -12,6 +12,8 @@ class BU_Navigation_Tree_View {
 	private $plugin;
 
 	private $query;
+	
+	public $hierarchy;
 
 	/**
 	 * Setup an object capable of creating the navigation management interface
@@ -60,6 +62,7 @@ class BU_Navigation_Tree_View {
 			'suppress_urls' => $this->settings['suppressUrls']
 		);
 		$this->query = new BU_Navigation_Tree_Query( $query_args );
+		$this->hierarchy = new BU_Navigation_Tree_Hierarchy( $this->query );
 
 		// No need to register scripts during AJAX requests
 		if( ! defined('DOING_AJAX') || ! DOING_AJAX ) {

--- a/includes/class-tree-view.php
+++ b/includes/class-tree-view.php
@@ -316,6 +316,37 @@ class BU_Navigation_Tree_View {
 
 }
 
+class BU_Navigation_Tree_Hierarchy {
+
+	const HIERARCHICAL_PROPERTIES = array( 'ID', 'excluded', 'menu_order', 'post_parent' );
+	public $query;
+
+	public function __construct( $query ) {
+		$this->query = $query;
+	}
+
+	public function as_object() {
+		$hierarchy = $this->query->posts_by_parent();
+		foreach ( $hierarchy as $parent ) {
+			foreach ( $parent as $child ) {
+				foreach ( $child as $prop_name => $prop_value ) {
+					if ( ! in_array( $prop_name, self::HIERARCHICAL_PROPERTIES ) ) {
+						unset( $child->$prop_name );
+					}
+				}
+			}
+		}
+
+		return $hierarchy;
+	}
+
+	public function as_hash() {
+		$obj = $this->as_object();
+		$str = json_encode( $obj );
+		return md5( $str );
+	}
+}
+
 /**
  * WP_Query-like class optimized for querying hierarchical post types
  *

--- a/includes/class-tree-view.php
+++ b/includes/class-tree-view.php
@@ -319,17 +319,33 @@ class BU_Navigation_Tree_View {
 
 }
 
+/**
+ * Collection of methods that allow the page hierarchy be represented as 
+ * a hash value. By comparing two hash values, we can tell if there were
+ * any changes in the hierarchy.
+ */
 class BU_Navigation_Tree_Hierarchy {
 
-	const HIERARCHICAL_PROPERTIES = array( 'ID', 'excluded', 'menu_order', 'post_parent' );
-	public $query;
+	/**
+	 * Holds the BU_Navigation_Tree_Query instance passed into constructor.
+	 */
+	private $tree_query;
 
-	public function __construct( $query ) {
-		$this->query = $query;
-	}
+	/**
+	 * Post properties that describe hierarchy. If any of these changed,
+	 * the hierarchy changed.
+	 */
+	const HIERARCHICAL_PROPERTIES = array( 'ID', 'menu_order', 'post_parent' );
 
-	public function as_object() {
-		$hierarchy = $this->query->posts_by_parent();
+	/**
+	 * By taking the posts structure and leaving only hierarchy-related
+	 * preperties of it, we get the object that stays the same as long as
+	 * the post hierarchy stays the same.
+	 * 
+	 * @return array Object that represents post tree hierarchy
+	 */
+	private function as_object() {
+		$hierarchy = $this->tree_query->posts_by_parent();
 		foreach ( $hierarchy as $parent ) {
 			foreach ( $parent as $child ) {
 				foreach ( $child as $prop_name => $prop_value ) {
@@ -343,6 +359,19 @@ class BU_Navigation_Tree_Hierarchy {
 		return $hierarchy;
 	}
 
+	/**
+	 * Constructor.
+	 */
+	public function __construct( BU_Navigation_Tree_Query $tree_query ) {
+		$this->tree_query = $tree_query;
+	}
+
+	/**
+	 * Gets hashed representation of the BU_Navigation_Tree_Query instance
+	 * passed into the constructor of this class.
+	 * 
+	 * @return String hashed representation of the post hierarchy
+	 */
 	public function as_hash() {
 		$obj = $this->as_object();
 		$str = json_encode( $obj );

--- a/templates/edit-order.php
+++ b/templates/edit-order.php
@@ -5,6 +5,7 @@
 
 	<div id="navman-container">
 		<form method="post" id="navman_form" action="">
+			<input type="hidden" id="navman-hash" name="navman-hash" value="<?php echo esc_attr( $tree->hierarchy->as_hash() ); ?>" />
 			<input type="hidden" id="navman-moves" name="navman-moves" value="" />
 			<input type="hidden" id="navman-inserts" name="navman-inserts" value="" />
 			<input type="hidden" id="navman-updates" name="navman-updates" value="" />


### PR DESCRIPTION
Adds hash of the post tree to the form submitted when page order changes. If the hash in the form doesn't match the hash of the current post tree, the form submission is rejected with an error message. This is done to prevent two people unknowingly submitting changes that override someone else's changes.