### PR TITLE
Introduce a caching layer in `bu_navigation_get_posts`

### DIFF
--- a/admin/manager.php
+++ b/admin/manager.php
@@ -415,6 +415,9 @@ class BU_Navigation_Admin_Manager {
 				// @todo notify user of error messages from WP_Error objects
 				$this->plugin->log( '%s - Errors encountered during navman save: %s', __METHOD__, print_r( $errors, true ) );
 			}
+
+			$bu_nav_posts_last_changed = microtime();
+			wp_cache_set( 'posts_last_changed', $bu_nav_posts_last_changed, 'bu-navigation-persistent' );
 		}
 
 		return $saved;


### PR DESCRIPTION
https://trello.com/c/eU9qfTAa/30-ca-6-bu-navigation

This approach leverages keys stored in a new cache group - `bu-navigation-persistent` (`bu-navigation` is set as [non-persistent](https://github.com/bu-ist/bu-navigation/blob/master/bu-navigation.php#L86)).

A copy of the `last_changed` cache key value from WP core is stored in this group with the `posts_last_changed` key, and is reset whenever changes to the menu are saved. This value is compared against core's `last_changed` value when determining whether to return the cached results of the query made in the `bu_navigation_get_posts` function. The query results themselves are stored with a key that uses the arguments passed to the function, JSON encoded and wrapped in `md5`.

I think this approach makes sense, but I appreciate that my understanding of the plugin as a whole may not be complete enough, and I could be missing something.