### PR TITLE
Address general PHP issues for 5.x upgrade preparation

### DIFF
--- a/includes/class-tree-view.php
+++ b/includes/class-tree-view.php
@@ -449,7 +449,7 @@ class BU_Navigation_Tree_Query {
 			)
 		);
 
-		$this->post_count = count($this->posts);
+		$this->post_count = ( $this->posts ) ? count( $this->posts ) : 0;
 
 		// Restore filters
 		remove_filter('bu_navigation_filter_pages', array( $this, 'filter_posts' ) );


### PR DESCRIPTION
* Check if `$this->posts` is truthy before passing to `count()`. (The `bu_navigation_get_posts()` function is used to define `$this->posts` here, and will return `false` if it doesn't find any results.)