### PR TITLE
Feature/widget refactor

### DIFF
--- a/bu-navigation-widget.php
+++ b/bu-navigation-widget.php
@@ -67,11 +67,11 @@ class BU_Widget_Pages extends WP_Widget {
 	 * Uses bu_navigation_gather_sections, bu_navigation_get_pages, bu_navigation_pages_by_parent, bu_navigation_get_label
 	 * from includes/library.php
 	 *
-	 * @param array $instance widget instance args, as passed to WP_Widget::widget.
+	 * @param WP_Post $post Root post as passed through global to the widget() method.
+	 * @param array   $instance widget instance args, as passed to WP_Widget::widget.
 	 * @return string HTML fragment with title
 	 */
-	public function section_title( $instance ) {
-		global $post;
+	public function section_title( $post, $instance ) {
 
 		$html  = '';
 		$title = '';
@@ -118,7 +118,7 @@ class BU_Widget_Pages extends WP_Widget {
 			return;
 		}
 
-		$title = $this->get_widget_title( $instance );
+		$title = $this->get_widget_title( $post, $instance );
 
 		// Set list arguments based on post type and navigation style.
 		$list_args = $this->get_list_args( $post, $instance );
@@ -196,10 +196,11 @@ class BU_Widget_Pages extends WP_Widget {
 	 *
 	 * @since 1.2.22
 	 *
-	 * @param array $instance The settings for the particular instance of the widget.
+	 * @param WP_Post $post Root post as passed through global to the widget() method.
+	 * @param array   $instance The settings for the particular instance of the widget.
 	 * @return string $title Empty string, plain text title, or anchor tag wrapped title string.
 	 */
-	private function get_widget_title( $instance ) {
+	private function get_widget_title( $post, $instance ) {
 		if ( 'none' === $instance['navigation_title'] ) {
 			return '';
 		}
@@ -214,7 +215,7 @@ class BU_Widget_Pages extends WP_Widget {
 		}
 
 		if ( 'section' === $instance['navigation_title'] ) {
-			return $this->section_title( $instance );
+			return $this->section_title( $post, $instance );
 		}
 
 		// In case the navigation_title option is something else, just return an empty string.

--- a/bu-navigation-widget.php
+++ b/bu-navigation-widget.php
@@ -145,7 +145,7 @@ class BU_Widget_Pages extends WP_Widget {
 	}
 
 	/**
-	 * Display the content navigation widget, overrides parent method.
+	 * Echos the content navigation widget content, overrides parent method.
 	 *
 	 * @param array $args Display arguments for WP_Widget.
 	 * @param array $instance The settings for the particular instance of the widget.
@@ -154,7 +154,7 @@ class BU_Widget_Pages extends WP_Widget {
 		global $post;
 
 		// Only display navigation widget for supported post types.
-		if ( ! in_array( $post->post_type, bu_navigation_supported_post_types() ) ) {
+		if ( ! in_array( $post->post_type, bu_navigation_supported_post_types(), true ) ) {
 			return;
 		}
 

--- a/bu-navigation-widget.php
+++ b/bu-navigation-widget.php
@@ -158,8 +158,6 @@ class BU_Widget_Pages extends WP_Widget {
 			return;
 		}
 
-		extract( $args );
-
 		$title = $this->get_widget_title( $args, $instance );
 
 		// Set list arguments based on post type and navigation style.
@@ -167,22 +165,26 @@ class BU_Widget_Pages extends WP_Widget {
 
 		do_action( 'bu_navigation_widget_before_list' );
 
-		// Fetch markup and display.
-		$out = bu_navigation_list_pages( apply_filters( 'widget_bu_pages_args', $list_args ) );
+		// Fetch markup.
+		$nav_list_markup = bu_navigation_list_pages( apply_filters( 'widget_bu_pages_args', $list_args ) );
 
-		if ( ! empty( $out ) ) {
+		// Only output anything at all if the is existing markup from list_pages.
+		if ( ! empty( $nav_list_markup ) ) {
 
-			printf( '%s<div id="contentnav">', $before_widget );
+			$output = sprintf( '%s<div id="contentnav">', $args['before_widget'] );
 
+			// Only add the title markup if the title isn't blank.
 			if ( $title ) {
-				echo $before_title . $title . $after_title;
+				$output .= $args['before_title'] . $title . $args['after_title'];
 			}
 
-			printf( '%s</div>', $out );
+			// Add content markup and closing tags.
+			$output .= sprintf( '%s</div>', $nav_list_markup ) . $args['after_widget'];
 
-			echo $after_widget;
-
+			// Echo assembled widget markup.
+			echo wp_kses_post( $output );
 		}
+
 	}
 
 	/**

--- a/bu-navigation-widget.php
+++ b/bu-navigation-widget.php
@@ -136,7 +136,7 @@ class BU_Widget_Pages extends WP_Widget {
 			return;
 		}
 
-		$title = $this->get_widget_title( $args, $instance );
+		$title = $this->get_widget_title( $instance );
 
 		// Set list arguments based on post type and navigation style.
 		$list_args = $this->get_list_args( $post, $instance );

--- a/bu-navigation-widget.php
+++ b/bu-navigation-widget.php
@@ -64,6 +64,9 @@ class BU_Widget_Pages extends WP_Widget {
 	/**
 	 * Returns HTML fragment containing a section title
 	 *
+	 * Uses bu_navigation_gather_sections, bu_navigation_get_pages, bu_navigation_pages_by_parent, bu_navigation_get_label
+	 * from includes/library.php
+	 *
 	 * @param array $args widget args, as passed to WP_Widget::widget.
 	 * @param array $instance widget instance args, as passed to WP_Widget::widget.
 	 * @return string HTML fragment with title

--- a/bu-navigation-widget.php
+++ b/bu-navigation-widget.php
@@ -67,11 +67,10 @@ class BU_Widget_Pages extends WP_Widget {
 	 * Uses bu_navigation_gather_sections, bu_navigation_get_pages, bu_navigation_pages_by_parent, bu_navigation_get_label
 	 * from includes/library.php
 	 *
-	 * @param array $args widget args, as passed to WP_Widget::widget.
 	 * @param array $instance widget instance args, as passed to WP_Widget::widget.
 	 * @return string HTML fragment with title
 	 */
-	public function section_title( $args, $instance ) {
+	public function section_title( $instance ) {
 		global $post;
 
 		$html       = '';
@@ -234,7 +233,7 @@ class BU_Widget_Pages extends WP_Widget {
 		}
 
 		if ( 'section' === $instance['navigation_title'] ) {
-			return $this->section_title( $args, $instance );
+			return $this->section_title( $instance );
 		}
 
 		// In case the navigation_title option is something else, just return an empty string.

--- a/bu-navigation-widget.php
+++ b/bu-navigation-widget.php
@@ -235,10 +235,10 @@ class BU_Widget_Pages extends WP_Widget {
 		$instance = $old_instance;
 		$instance = wp_parse_args( $instance, $this->defaults );
 
-		$instance['navigation_title']      = ( in_array( $new_instance['navigation_title'], $this->title_options ) ) ? $new_instance['navigation_title'] : 'none';
-		$instance['navigation_title_text'] = ( $instance['navigation_title'] == 'static' ) ? sanitize_text_field( $new_instance['navigation_title_text'] ) : '';
-		$instance['navigation_title_url']  = ( $instance['navigation_title'] == 'static' ) ? sanitize_text_field( $new_instance['navigation_title_url'] ) : '';
-		$instance['navigation_style']      = ( in_array( $new_instance['navigation_style'], $this->styles ) ) ? $new_instance['navigation_style'] : 'site';
+		$instance['navigation_title']      = ( in_array( $new_instance['navigation_title'], $this->title_options, true ) ) ? $new_instance['navigation_title'] : 'none';
+		$instance['navigation_title_text'] = ( 'static' === $instance['navigation_title'] ) ? sanitize_text_field( $new_instance['navigation_title_text'] ) : '';
+		$instance['navigation_title_url']  = ( 'static' === $instance['navigation_title'] ) ? sanitize_text_field( $new_instance['navigation_title_url'] ) : '';
+		$instance['navigation_style']      = ( in_array( $new_instance['navigation_style'], $this->styles, true ) ) ? $new_instance['navigation_style'] : 'site';
 
 		return $instance;
 	}
@@ -252,10 +252,10 @@ class BU_Widget_Pages extends WP_Widget {
 
 		$instance = wp_parse_args( $instance, $this->defaults );
 
-		$navigation_title      = ( in_array( $instance['navigation_title'], $this->title_options ) ) ? $instance['navigation_title'] : 'none';
+		$navigation_title      = ( in_array( $instance['navigation_title'], $this->title_options, true ) ) ? $instance['navigation_title'] : 'none';
 		$navigation_title_text = esc_attr( $instance['navigation_title_text'] );
 		$navigation_title_url  = esc_attr( $instance['navigation_title_url'] );
-		$navigation_style      = ( in_array( $instance['navigation_style'], $this->styles ) ) ? $instance['navigation_style'] : 'site';
+		$navigation_style      = ( in_array( $instance['navigation_style'], $this->styles, true ) ) ? $instance['navigation_style'] : 'site';
 
 		include BU_NAV_PLUGIN_DIR . '/templates/widget-form.php';
 	}

--- a/bu-navigation-widget.php
+++ b/bu-navigation-widget.php
@@ -102,16 +102,17 @@ class BU_Widget_Pages extends WP_Widget {
 	/**
 	 * Get site title
 	 *
-	 * Private convenience method to make it easier to give section_title multiple early return options.
+	 * Gets the title and href from the site and returns them formatted for use as a widget title.
+	 * It is a protected convenience method to make it easier to give section_title multiple early return options.
 	 * There are more than one condition that make section_title want to return the overall site title
-	 * as the widget title.  This function gets the title and href from the site and returns them formatted.
+	 * as the widget title.
 	 *
 	 * @since 1.2.22
 	 *
 	 * @param string $wrapped_title_format An sprintf format string to render the title and href as an html fragement.
 	 * @return string Formatted html fragment with the site title and link.
 	 */
-	private function get_site_title( $wrapped_title_format ) {
+	protected function get_site_title( $wrapped_title_format ) {
 		$title = get_bloginfo( 'name' );
 		$href  = trailingslashit( get_bloginfo( 'url' ) );
 		return sprintf( $wrapped_title_format, esc_attr( $href ), $title );
@@ -205,7 +206,7 @@ class BU_Widget_Pages extends WP_Widget {
 	 * 2- the static title
 	 * 3- the section title as returned by section_title()
 	 *
-	 * This private helper function sorts out those scenarios based on the instance options.
+	 * This helper function sorts out those scenarios based on the instance options.
 	 *
 	 * @since 1.2.22
 	 *
@@ -213,7 +214,7 @@ class BU_Widget_Pages extends WP_Widget {
 	 * @param array   $instance The settings for the particular instance of the widget.
 	 * @return string $title Empty string, plain text title, or anchor tag wrapped title string.
 	 */
-	private function get_widget_title( $post, $instance ) {
+	protected function get_widget_title( $post, $instance ) {
 		if ( 'none' === $instance['navigation_title'] ) {
 			return '';
 		}
@@ -248,7 +249,7 @@ class BU_Widget_Pages extends WP_Widget {
 	 *
 	 * @return array Arguements for the bu_navigation_list_pages() query in library.php
 	 */
-	private function get_list_args( $post, $instance ) {
+	protected function get_list_args( $post, $instance ) {
 
 		// Prepare arguments to bu_navigation_list_pages.
 		$list_args = array(
@@ -298,7 +299,7 @@ class BU_Widget_Pages extends WP_Widget {
 	 * @param string $post_type Post type of the post being rendered.
 	 * @return string Post Id of the grandparent post for the widget title.
 	 */
-	private function get_adaptive_section_id( $sections, $post_type ) {
+	protected function get_adaptive_section_id( $sections, $post_type ) {
 		// Fetch post list, possibly limited to specific sections.
 		$page_args       = array(
 			'sections'      => $sections,
@@ -338,7 +339,7 @@ class BU_Widget_Pages extends WP_Widget {
 	 * @param string  $nav_style The navigation style of the widget (mode).
 	 * @return int Either a post id for the title post, or zero if there is no appropriate match.
 	 */
-	private function get_title_post_id_for_child( $post, $nav_style ) {
+	protected function get_title_post_id_for_child( $post, $nav_style ) {
 		// Site mode doesn't need a title post, skip gather_section().
 		if ( 'site' === $nav_style ) {
 			return 0;

--- a/bu-navigation-widget.php
+++ b/bu-navigation-widget.php
@@ -1,210 +1,244 @@
 <?php
-/*
+/**
  * Alternative content (side) navigation widget
  * Niall Kavanagh
  * ntk@bu.edu
+ *
+ * @package BU_Navigation
  */
 
-define( 'BU_WIDGET_PAGES_LIST_CLASS', 'smartnav level1' );			// default class for list
-define( 'BU_WIDGET_PAGES_LIST_ID', 'contentnavlist' );				// default element id for list
+// Default class for list.  UNUSED in the plugin and the BU CMS build.  Should be removed.
+define( 'BU_WIDGET_PAGES_LIST_CLASS', 'smartnav level1' );
 
-define( 'BU_WIDGET_CONTENTNAV_BEFORE', '<div id="contentnav">' );	// default HTML fragment open
-define( 'BU_WIDGET_CONTENTNAV_AFTER', '</div>' );					// default HTML fragment close
+// Default element id for list.
+define( 'BU_WIDGET_PAGES_LIST_ID', 'contentnavlist' );
 
+// Default HTML fragment open. UNUSED in the plugin and the BU CMS build.  Should be removed.
+define( 'BU_WIDGET_CONTENTNAV_BEFORE', '<div id="contentnav">' );
+
+// Default HTML fragment close. UNUSED in the plugin and the BU CMS build.  Should be removed.
+define( 'BU_WIDGET_CONTENTNAV_AFTER', '</div>' );
+
+/**
+ * Widget for displaying navigation.
+ */
 class BU_Widget_Pages extends WP_Widget {
 
+	/**
+	 * Options for displaying the widget title.
+	 *
+	 * @var array
+	 */
 	public $title_options = array( 'none', 'section', 'static' );
+
+	/**
+	 * Options for the widget display style.
+	 *
+	 * @var array
+	 */
 	public $styles = array( 'site', 'section', 'adaptive' );
 
+	/**
+	 * Array of defaults for the widget.
+	 *
+	 * @var array
+	 */
 	public $defaults = array(
-			'navigation_title' => 'none',
-			'navigation_title_text' => '',
-			'navigation_title_url' => '',
-			'navigation_style' => 'site'
-			);
+		'navigation_title'      => 'none',
+		'navigation_title_text' => '',
+		'navigation_title_url'  => '',
+		'navigation_style'      => 'site',
+	);
 
+	/**
+	 * Constructor that registers with the parent class.
+	 */
 	public function __construct() {
-		$widget_ops = array( 'classname' => 'widget_bu_pages', 'description' => __( "Navigation list of your site's pages", 'bu-navigation' ) );
-		parent::__construct( 'bu_pages', __('Content Navigation', 'bu-navigation' ), $widget_ops );
+		$widget_ops = array(
+			'classname'   => 'widget_bu_pages',
+			'description' => __( "Navigation list of your site's pages", 'bu-navigation' ),
+		);
+		parent::__construct( 'bu_pages', __( 'Content Navigation', 'bu-navigation' ), $widget_ops );
 	}
 
 	/**
 	 * Returns HTML fragment containing a section title
 	 *
-	 * @param array $args widget args, as passed to WP_Widget::widget
-	 * @param array $instance widget instance args, as passed to WP_Widget::widget
+	 * @param array $args widget args, as passed to WP_Widget::widget.
+	 * @param array $instance widget instance args, as passed to WP_Widget::widget.
 	 * @return string HTML fragment with title
 	 */
 	public function section_title( $args, $instance ) {
 		global $post;
 
-		$html = $title = $href = '';
+		$html       = '';
+		$title      = '';
+		$href       = '';
 		$section_id = 0;
 
-		// Determine which post to use for the section title
+		// Determine which post to use for the section title.
 		if ( ! empty( $instance['navigation_style'] ) && $instance['navigation_style'] != 'site' ) {
 
-			// Gather ancestors
+			// Gather ancestors.
 			$sections = bu_navigation_gather_sections( $post->ID, array( 'post_types' => $post->post_type ) );
 
-			// Adaptive navigation style uses the grandparent of current post
+			// Adaptive navigation style uses the grandparent of current post.
 			if ( $instance['navigation_style'] == 'adaptive' ) {
 
-				// Fetch post list, possibly limited to specific sections
-				$page_args = array(
-					'sections' => $sections,
-					'post_types' => array( $post->post_type ),
+				// Fetch post list, possibly limited to specific sections.
+				$page_args       = array(
+					'sections'      => $sections,
+					'post_types'    => array( $post->post_type ),
 					'include_links' => false,
-					);
-				$pages = bu_navigation_get_pages( $page_args );
+				);
+				$pages           = bu_navigation_get_pages( $page_args );
 				$pages_by_parent = bu_navigation_pages_by_parent( $pages );
 
 				$last_section = array_pop( $sections );
 				array_push( $sections, $last_section );
 
 				if ( array_key_exists( $last_section, $pages_by_parent ) &&
-				     is_array( $pages_by_parent[$last_section] ) &&
-				     ( count( $pages_by_parent[$last_section] ) > 0 )
+					is_array( $pages_by_parent[ $last_section ] ) &&
+					( count( $pages_by_parent[ $last_section ] ) > 0 )
 				   ) {
-					// Last section has children, so its parent will be section title
+					// Last section has children, so its parent will be section title.
 					$grandparent_offset = count( $sections ) - 2;
 				} else {
-					// Last section has no children, so its grandparent will be the section title
+					// Last section has no children, so its grandparent will be the section title.
 					$grandparent_offset = count( $sections ) - 3;
 				}
 
-				if ( isset( $sections[$grandparent_offset] ) ) {
-					$section_id = $sections[$grandparent_offset];
+				if ( isset( $sections[ $grandparent_offset ] ) ) {
+					$section_id = $sections[ $grandparent_offset ];
 				}
 			} else {
-				// Default to top level post (if we have one)
+				// Default to top level post (if we have one).
 				if ( isset( $sections[1] ) ) {
 					$section_id = $sections[1];
 				}
 			}
-
 		}
 
-		// Use section post for title
+		// Use section post for title.
 		if ( $section_id ) {
 			$section = get_post( $section_id );
 
-			// Prevent usage of non-published posts as titles
+			// Prevent usage of non-published posts as titles.
 			if ( 'publish' === $section->post_status ) {
-				// Second argument prevents usage of default (no title) label
+				// Second argument prevents usage of default (no title) label.
 				$title = bu_navigation_get_label( $section, '' );
-				$href = get_permalink( $section->ID );
+				$href  = get_permalink( $section->ID );
 			}
 		}
 
-		// Fallback to site title if we're still empty
+		// Fallback to site title if we're still empty.
 		if ( empty( $title ) ) {
 			$title = get_bloginfo( 'name' );
-			$href = trailingslashit( get_bloginfo( 'url' ) );
+			$href  = trailingslashit( get_bloginfo( 'url' ) );
 		}
 
 		if ( $title && $href ) {
-			$html =  sprintf( "<a class=\"content_nav_header\" href=\"%s\">%s</a>\n", esc_attr( $href ), $title );
+			$html = sprintf( "<a class=\"content_nav_header\" href=\"%s\">%s</a>\n", esc_attr( $href ), $title );
 		}
 
 		return $html;
-
 	}
 
 	/**
-	 * Display the content navigation widget
+	 * Display the content navigation widget, overrides parent method.
 	 *
-	 * @param array $args widget args
-	 * @param array $instance widget instance args
+	 * @param array $args Display arguments for WP_Widget.
+	 * @param array $instance The settings for the particular instance of the widget.
 	 */
 	public function widget( $args, $instance ) {
 		global $post;
 
-		// Only display navigation widget for supported post types
-		if ( ! in_array( $post->post_type, bu_navigation_supported_post_types() ) )
+		// Only display navigation widget for supported post types.
+		if ( ! in_array( $post->post_type, bu_navigation_supported_post_types() ) ) {
 			return;
+		}
 
 		extract( $args );
 
 		$title = '';
 
-		// Set widget title
+		// Set widget title.
 		if ( ( $instance['navigation_title'] == 'static' ) && ( ! empty( $instance['navigation_title_text'] ) ) ) {
 
 			$title = apply_filters( 'widget_title', $instance['navigation_title_text'] );
 
-			// Wrap with anchor tag if URL is present
+			// Wrap with anchor tag if URL is present.
 			if ( ! empty( $instance['navigation_title_url'] ) ) {
 				$title = sprintf( '<a class="content_nav_header" href="%s">%s</a>', $instance['navigation_title_url'], $title );
 			}
+		} elseif ( $instance['navigation_title'] == 'section' ) {
 
-		} else if ( $instance['navigation_title'] == 'section' ) {
-
-			// Use navigation label of top level post for current section
+			// Use navigation label of top level post for current section.
 			$title = $this->section_title( $args, $instance );
 
 		}
 
 		// Prepare arguments to bu_navigation_list_pages
 		$list_args = array(
-			'page_id' => $post->ID,
-			'title_li' => '',
-			'echo' => 0,
+			'page_id'      => $post->ID,
+			'title_li'     => '',
+			'echo'         => 0,
 			'container_id' => BU_WIDGET_PAGES_LIST_ID,
-			'post_types' => $post->post_type,
-			);
+			'post_types'   => $post->post_type,
+		);
 
-		// Set list arguments based on navigation style
+		// Set list arguments based on navigation style.
 		if ( array_key_exists( 'navigation_style', $instance ) ) {
 
 			$list_args['style'] = $instance['navigation_style'];
 
 			if ( $instance['navigation_style'] == 'section' ) {
 				$list_args['navigate_in_section'] = 1;
-				if ( is_404() ) return '';
-			} else if ( $instance['navigation_style'] == 'adaptive' ) {
+				if ( is_404() ) {
+					return '';
+				}
+			} elseif ( $instance['navigation_style'] == 'adaptive' ) {
 				add_action( 'bu_navigation_widget_before_list', 'bu_navigation_widget_adaptive_before_list' );
 			}
-
 		} else {
 			$GLOBALS['bu_navigation_plugin']->log( 'No nav label widget style set!' );
 		}
 
 		do_action( 'bu_navigation_widget_before_list' );
 
-		// Fetch markup and display
+		// Fetch markup and display.
 		$out = bu_navigation_list_pages( apply_filters( 'widget_bu_pages_args', $list_args ) );
 
 		if ( ! empty( $out ) ) {
 
-			printf('%s<div id="contentnav">', $before_widget);
+			printf( '%s<div id="contentnav">', $before_widget );
 
-			if ( $title )
+			if ( $title ) {
 				echo $before_title . $title . $after_title;
+			}
 
-			printf('%s</div>', $out);
+			printf( '%s</div>', $out );
 
 			echo $after_widget;
 
 		}
-
 	}
 
 	/**
 	 * Save handler for the content navigation widget
 	 *
-	 * @param array $new_instance updated widget parameters
-	 * @param array $old_instance original widget parameters
+	 * @param array $new_instance updated widget parameters.
+	 * @param array $old_instance original widget parameters.
 	 */
 	public function update( $new_instance, $old_instance ) {
 
 		$instance = $old_instance;
 		$instance = wp_parse_args( $instance, $this->defaults );
 
-		$instance['navigation_title'] = ( in_array( $new_instance['navigation_title'], $this->title_options ) ) ? $new_instance['navigation_title'] : 'none';
+		$instance['navigation_title']      = ( in_array( $new_instance['navigation_title'], $this->title_options ) ) ? $new_instance['navigation_title'] : 'none';
 		$instance['navigation_title_text'] = ( $instance['navigation_title'] == 'static' ) ? sanitize_text_field( $new_instance['navigation_title_text'] ) : '';
-		$instance['navigation_title_url'] = ( $instance['navigation_title'] == 'static' ) ? sanitize_text_field( $new_instance['navigation_title_url'] ) : '';
-		$instance['navigation_style'] = ( in_array( $new_instance['navigation_style'], $this->styles ) ) ? $new_instance['navigation_style'] : 'site';
+		$instance['navigation_title_url']  = ( $instance['navigation_title'] == 'static' ) ? sanitize_text_field( $new_instance['navigation_title_url'] ) : '';
+		$instance['navigation_style']      = ( in_array( $new_instance['navigation_style'], $this->styles ) ) ? $new_instance['navigation_style'] : 'site';
 
 		return $instance;
 	}
@@ -212,19 +246,17 @@ class BU_Widget_Pages extends WP_Widget {
 	/**
 	 * Display the content navigation widget form
 	 *
-	 * @param array $instance the specific widget instance being displayed
+	 * @param array $instance the specific widget instance being displayed.
 	 */
 	public function form( $instance ) {
 
 		$instance = wp_parse_args( $instance, $this->defaults );
 
-		$navigation_title = ( in_array( $instance['navigation_title'], $this->title_options ) ) ? $instance['navigation_title'] : 'none';
+		$navigation_title      = ( in_array( $instance['navigation_title'], $this->title_options ) ) ? $instance['navigation_title'] : 'none';
 		$navigation_title_text = esc_attr( $instance['navigation_title_text'] );
-		$navigation_title_url = esc_attr( $instance['navigation_title_url'] );
-		$navigation_style = ( in_array( $instance['navigation_style'], $this->styles ) ) ? $instance['navigation_style'] : 'site';
+		$navigation_title_url  = esc_attr( $instance['navigation_title_url'] );
+		$navigation_style      = ( in_array( $instance['navigation_style'], $this->styles ) ) ? $instance['navigation_style'] : 'site';
 
-		include( BU_NAV_PLUGIN_DIR . '/templates/widget-form.php' );
-
+		include BU_NAV_PLUGIN_DIR . '/templates/widget-form.php';
 	}
-
 }

--- a/bu-navigation-widget.php
+++ b/bu-navigation-widget.php
@@ -308,7 +308,7 @@ class BU_Widget_Pages extends WP_Widget {
 		// Fetch post list, possibly limited to specific sections.
 		$page_args       = array(
 			'sections'      => $sections,
-			'post_types'    => array( $post->post_type ),
+			'post_types'    => array( $post_type ),
 			'include_links' => false,
 		);
 		$pages           = bu_navigation_get_pages( $page_args );

--- a/bu-navigation-widget.php
+++ b/bu-navigation-widget.php
@@ -144,23 +144,24 @@ class BU_Widget_Pages extends WP_Widget {
 		// Fetch markup.
 		$nav_list_markup = bu_navigation_list_pages( apply_filters( 'widget_bu_pages_args', $list_args ) );
 
-		// Only output anything at all if the is existing markup from list_pages.
-		if ( ! empty( $nav_list_markup ) ) {
-
-			$output = sprintf( '%s<div id="contentnav">', $args['before_widget'] );
-
-			// Only add the title markup if the title isn't blank.
-			if ( $title ) {
-				$output .= $args['before_title'] . $title . $args['after_title'];
-			}
-
-			// Add content markup and closing tags.
-			$output .= sprintf( '%s</div>', $nav_list_markup ) . $args['after_widget'];
-
-			// Echo assembled widget markup.
-			echo wp_kses_post( $output );
+		// Only output anything at all if there is existing markup from list_pages.
+		if ( empty( $nav_list_markup ) ) {
+			return;
 		}
 
+		// Assemble the markup into $output, starting with the opening tags.
+		$output = sprintf( '%s<div id="contentnav">', $args['before_widget'] );
+
+		// Only add the title markup if the title isn't blank.
+		if ( $title ) {
+			$output .= $args['before_title'] . $title . $args['after_title'];
+		}
+
+		// Add content markup and closing tags.
+		$output .= sprintf( '%s</div>', $nav_list_markup ) . $args['after_widget'];
+
+		// Echo assembled widget markup.
+		echo wp_kses_post( $output );
 	}
 
 	/**

--- a/bu-navigation-widget.php
+++ b/bu-navigation-widget.php
@@ -214,11 +214,10 @@ class BU_Widget_Pages extends WP_Widget {
 	 *
 	 * @since 1.2.22
 	 *
-	 * @param array $args widget args, as passed to WP_Widget::widget.
 	 * @param array $instance The settings for the particular instance of the widget.
 	 * @return string $title Empty string, plain text title, or anchor tag wrapped title string.
 	 */
-	private function get_widget_title( $args, $instance ) {
+	private function get_widget_title( $instance ) {
 		if ( 'none' === $instance['navigation_title'] ) {
 			return '';
 		}


### PR DESCRIPTION
This is a refactor of `bu-navigation-widget.php` aimed at getting into compliance with the WordPress coding standards and improving the maintainability score in code climate (currently a "C").

One of the issues with the current state of the code is a lot of nested conditionals that make the logical flow difficult to comprehend (thus the low code climate score).  I found [this article on dealing with nested conditionals](https://carlalexander.ca/mastering-php-conditionals/) to be helpful source of strategies to clarify the logical flow.

Because there's a lot of branching based on the instance styles, I've used the early return pattern in some places to untangle it.  I've also broken out 3 new private methods to better encapsulate some of the complexity.

The refactored code doesn't change any functionality, the widget should behave exactly the same before and after.  I've tried to alter as little as possible to keep this a targeted PR.  This should provide a more stable base for further refactoring (for example clarifying variable names, further detangling the branching structure, etc.)
