### PR TITLE
add esc url

### DIFF
--- a/includes/library.php
+++ b/includes/library.php
@@ -644,7 +644,7 @@ function bu_navigation_format_page( $page, $args = '' ) {
 		);
 
 	if ( isset( $page->url ) && ! empty( $page->url ) )
-		$attrs['href'] = $page->url;
+		$attrs['href'] = esc_url( $page->url );
 
 	if ( isset( $page->target ) && $page->target == 'new' )
 		$attrs['target'] = '_blank';


### PR DESCRIPTION
While processing the menu through [DOMdocument](https://www.php.net/manual/en/class.domdocument.php) a warning was occurring.

`DOMDocument::loadHTML(): htmlParseEntityRef: expecting ';' in Entity`

This adds the [esc_url()](https://developer.wordpress.org/reference/functions/esc_url/) to encode ampersands and follow [best practices](https://codex.wordpress.org/Data_Validation#URLs). 


