### PR TITLE
Refactor get_posts()

### DIFF
--- a/includes/library.php
+++ b/includes/library.php
@@ -682,18 +682,18 @@ function bu_navigation_get_pages( $args = '' ) {
 		'pages'                 => null,
 		'suppress_filter_pages' => false,
 	);
-	$r        = wp_parse_args( $args, $defaults );
+	$new_args = wp_parse_args( $args, $defaults );
 
-	// Legacy arg translation
-	if ( ! is_null( $r['pages'] ) ) {
-		$r['post__in'] = $r['pages'];
-		unset( $r['pages'] );
+	// Legacy arg translation.
+	if ( ! is_null( $new_args['pages'] ) ) {
+		$new_args['post__in'] = $new_args['pages'];
+		unset( $new_args['pages'] );
 	}
 
-	$r['suppress_filter_posts'] = $r['suppress_filter_pages'];
-	unset( $r['suppress_filter_pages'] );
+	$new_args['suppress_filter_posts'] = $new_args['suppress_filter_pages'];
+	unset( $new_args['suppress_filter_pages'] );
 
-	return bu_navigation_get_posts( $r );
+	return bu_navigation_get_posts( $new_args );
 }
 
 /**

--- a/includes/library.php
+++ b/includes/library.php
@@ -703,15 +703,17 @@ function bu_navigation_get_pages( $args = '' ) {
  * @return array Array of arrays indexed on post.ID with second-level array containing the immediate children of that post
  */
 function bu_navigation_pages_by_parent( $pages ) {
-	$pages_by_parent = array();
 
-	if ( is_array( $pages ) && count( $pages ) > 0 ) {
-		foreach ( $pages as $page ) {
-			if ( ! array_key_exists( $page->post_parent, $pages_by_parent ) ) {
-				$pages_by_parent[ $page->post_parent ] = array();
-			}
-			array_push( $pages_by_parent[ $page->post_parent ], $page );
+	if ( ! is_array( $pages ) && ! count( $pages ) > 0 ) {
+		return array();
+	}
+
+	$pages_by_parent = array();
+	foreach ( $pages as $page ) {
+		if ( ! array_key_exists( $page->post_parent, $pages_by_parent ) ) {
+			$pages_by_parent[ $page->post_parent ] = array();
 		}
+		array_push( $pages_by_parent[ $page->post_parent ], $page );
 	}
 
 	return $pages_by_parent;

--- a/includes/library.php
+++ b/includes/library.php
@@ -656,13 +656,12 @@ function _get_posts_where_clause( $post_types, $include_links, $post_status, $se
 		$where      .= " AND post_status IN ('$post_status')";
 	}
 
-	// Validate sections parameter such that it is an array, coerce the values to absolute integers, and enforce uniqueness.
-	// This seems like overkill, but is included for consistency with prior behavior.
-	$parsed_sections = is_array( $sections ) ? array_unique( array_map( 'absint', $sections ) ) : array();
-	$sections_list   = implode( ',', $parsed_sections );
-
-	// Limit result set to children of specified page ids, if present.
-	$where .= ! empty( $sections_list ) ? " AND post_parent IN ($sections_list)" : '';
+	// Limit result set to posts in specific sections.
+	if ( is_array( $sections ) && ( count( $sections ) > 0 ) ) {
+		$sections = array_map( 'absint', $sections );
+		$sections = implode( ',', array_unique( $sections ) );
+		$where   .= " AND post_parent IN ($sections)";
+	}
 
 	// Validate posts__in parameter such that it is an array, coerce the values to absolute integers, and enforce uniqueness.
 	$parsed_post__in = is_array( $post__in ) ? array_unique( array_map( 'absint', $post__in ) ) : array();

--- a/includes/library.php
+++ b/includes/library.php
@@ -541,7 +541,7 @@ function _bu_navigation_page_uri_ancestors_fields( $fields ) {
 function bu_navigation_get_posts( $args = '' ) {
 	global $wpdb, $bu_navigation_plugin;
 
-	$defaults = array(
+	$defaults    = array(
 		'post_types'            => array( 'page' ),
 		'post_status'           => array( 'publish' ),
 		'sections'              => null,
@@ -551,7 +551,7 @@ function bu_navigation_get_posts( $args = '' ) {
 		'suppress_filter_posts' => false,
 		'suppress_urls'         => false,
 	);
-	$parsed_args        = wp_parse_args( $args, $defaults );
+	$parsed_args = wp_parse_args( $args, $defaults );
 
 	// Start building the query.
 	$where   = '';

--- a/includes/library.php
+++ b/includes/library.php
@@ -673,12 +673,15 @@ function bu_navigation_post_types_to_select( $post_types, $include_links ) {
 	$post_types = (array) $post_types;
 	$post_types = array_map( 'trim', $post_types );
 
-	// If links are included, add them to the post types array.
-	if ( $include_links && ! in_array( BU_NAVIGATION_LINK_POST_TYPE, $post_types ) ) {
-		if ( in_array( 'page', $post_types ) && ( count( $post_types ) == 1 ) ) {
-			$post_types[] = BU_NAVIGATION_LINK_POST_TYPE;
-		}
+	// If include_links is set in the args, add the link type to the post types array (if it's not there already).
+	if ( $include_links
+		&& ! in_array( BU_NAVIGATION_LINK_POST_TYPE, $post_types, true )
+		&& in_array( 'page', $post_types, true ) // Not clear why links are only added if pages are there.
+		&& count( $post_types ) === 1 // Not clear why links are only added if there's only one other existing post type.
+	) {
+		$post_types[] = BU_NAVIGATION_LINK_POST_TYPE;
 	}
+
 	if ( is_object( $bu_navigation_plugin ) && ! $bu_navigation_plugin->supports( 'links' ) ) {
 		$index = array_search( BU_NAVIGATION_LINK_POST_TYPE, $post_types );
 		if ( $index !== false ) {

--- a/includes/library.php
+++ b/includes/library.php
@@ -318,20 +318,31 @@ function bu_navigation_get_page_depth( $page_id, $all_sections = null ) {
  * @return array $pages The input array with $post->url set to the permalink for each post.
  */
 function bu_navigation_get_urls( $pages ) {
-	if ( ( is_array( $pages ) ) && ( count( $pages ) > 0 ) ) {
-		foreach ( $pages as $page ) {
-			$url = '';
-			if ( 'page' === $page->post_type ) {
-				$url = bu_navigation_get_page_link( $page, $pages );
-			} elseif ( BU_NAVIGATION_LINK_POST_TYPE === $page->post_type ) {
-				$url = $page->post_content;
-			} else {
-				$url = bu_navigation_get_post_link( $page, $pages );
-			}
-			$page->url = $url;
-		}
+	// If the $pages parameter isn't an array, or is empty, return it back unaltered.
+	if ( empty( $pages ) || ! is_array( $pages ) ) {
+		return $pages;
 	}
-	return $pages;
+
+	$pages_with_url = array_map( function ( $page ) use ( $pages ) {
+		// Use get_page_link for pages.
+		if ( 'page' === $page->post_type ) {
+			$page->url = bu_navigation_get_page_link( $page, $pages );
+			return $page;
+		}
+
+		// Use post_content as url for the 'link' type.
+		if ( BU_NAVIGATION_LINK_POST_TYPE === $page->post_type ) {
+			$page->url = $page->post_content;
+			return $page;
+		}
+
+		// Use post_link for everything else.
+		$page->url = bu_navigation_get_post_link( $page, $pages );
+		return $page;
+
+	}, $pages );
+
+	return $pages_with_url;
 }
 
 /**

--- a/includes/library.php
+++ b/includes/library.php
@@ -581,21 +581,22 @@ function bu_navigation_get_posts( $args = '' ) {
 	// Result sorting clause.
 	$orderby = 'ORDER BY post_parent ASC, menu_order ASC';
 
-	// Execute query, fetch results as objects in an array keyed on posts.ID
+	// Execute query, fetch results as objects in an array keyed on posts.ID.
 	$posts = $wpdb->get_results(
 		"SELECT $fields FROM $wpdb->posts WHERE 1=1 $where $orderby",
 		OBJECT_K
-	);
-	if ( ! is_array( $posts ) || ( count( $posts ) == 0 ) ) {
+	); // db call ok; no-cache ok.
+
+	if ( ! is_array( $posts ) || ( count( $posts ) === 0 ) ) {
 		return false;
 	}
 
-	// Add url property to each post object ($post->url = permalink)
+	// Add url property to each post object ($post->url = permalink).
 	if ( ! $parsed_args['suppress_urls'] ) {
 		$posts = bu_navigation_get_urls( $posts );
 	}
 
-	// Allow custom filtering of posts retrieved using this function
+	// Allow custom filtering of posts retrieved using this function.
 	if ( ! $parsed_args['suppress_filter_posts'] ) {
 		$posts = apply_filters( 'bu_navigation_filter_posts', $posts );
 		$posts = apply_filters( 'bu_navigation_filter_pages', $posts );

--- a/includes/library.php
+++ b/includes/library.php
@@ -640,7 +640,6 @@ function _get_posts_where_clause( $post_types, $include_links, $post_status, $se
 	if ( 'any' !== $post_status ) {
 		// Explode strings to arrays, and coerce anything else to an array.  Probably overkill, but matches previous behavior.
 		$post_status = ( is_string( $post_status ) ) ? explode( ',', $post_status ) : (array) $post_status;
-		$post_status = (array) $post_status;
 
 		$post_status = implode( "','", array_map( 'trim', $post_status ) );
 		$where      .= " AND post_status IN ('$post_status')";

--- a/includes/library.php
+++ b/includes/library.php
@@ -551,7 +551,7 @@ function bu_navigation_get_posts( $args = '' ) {
 		'suppress_filter_posts' => false,
 		'suppress_urls'         => false,
 	);
-	$r        = wp_parse_args( $args, $defaults );
+	$parsed_args        = wp_parse_args( $args, $defaults );
 
 	// Start building the query.
 	$where   = '';
@@ -575,7 +575,7 @@ function bu_navigation_get_posts( $args = '' ) {
 	$fields = implode( ',', $fields );
 
 	// Append post types.
-	$post_types = $r['post_types'];
+	$post_types = $parsed_args['post_types'];
 	if ( 'any' != $post_types ) {
 		if ( is_string( $post_types ) ) {
 			$post_types = explode( ',', $post_types );
@@ -585,7 +585,7 @@ function bu_navigation_get_posts( $args = '' ) {
 		$post_types = array_map( 'trim', $post_types );
 
 		// If links are included, add them to the post types array.
-		if ( $r['include_links'] && ! in_array( BU_NAVIGATION_LINK_POST_TYPE, $post_types ) ) {
+		if ( $parsed_args['include_links'] && ! in_array( BU_NAVIGATION_LINK_POST_TYPE, $post_types ) ) {
 			if ( in_array( 'page', $post_types ) && ( count( $post_types ) == 1 ) ) {
 				$post_types[] = BU_NAVIGATION_LINK_POST_TYPE;
 			}
@@ -602,7 +602,7 @@ function bu_navigation_get_posts( $args = '' ) {
 	}
 
 	// Append post statuses.
-	$post_status = $r['post_status'];
+	$post_status = $parsed_args['post_status'];
 	if ( 'any' != $post_status ) {
 		if ( is_string( $post_status ) ) {
 			$post_status = explode( ',', $post_status );
@@ -614,15 +614,15 @@ function bu_navigation_get_posts( $args = '' ) {
 	}
 
 	// Limit result set to posts in specific sections
-	if ( is_array( $r['sections'] ) && ( count( $r['sections'] ) > 0 ) ) {
-		$sections = array_map( 'absint', $r['sections'] );
+	if ( is_array( $parsed_args['sections'] ) && ( count( $parsed_args['sections'] ) > 0 ) ) {
+		$sections = array_map( 'absint', $parsed_args['sections'] );
 		$sections = implode( ',', array_unique( $sections ) );
 		$where   .= " AND post_parent IN ($sections)";
 	}
 
 	// Limit to specific posts
-	if ( is_array( $r['post__in'] ) && ( count( $r['post__in'] ) > 0 ) ) {
-		$post__in = array_map( 'absint', $r['post__in'] );
+	if ( is_array( $parsed_args['post__in'] ) && ( count( $parsed_args['post__in'] ) > 0 ) ) {
+		$post__in = array_map( 'absint', $parsed_args['post__in'] );
 		$post__in = implode( ',', array_unique( $post__in ) );
 		$where   .= " AND ID IN($post__in)";
 	}
@@ -640,23 +640,23 @@ function bu_navigation_get_posts( $args = '' ) {
 	}
 
 	// Add url property to each post object ($post->url = permalink)
-	if ( ! $r['suppress_urls'] ) {
+	if ( ! $parsed_args['suppress_urls'] ) {
 		$posts = bu_navigation_get_urls( $posts );
 	}
 
 	// Allow custom filtering of posts retrieved using this function
-	if ( ! $r['suppress_filter_posts'] ) {
+	if ( ! $parsed_args['suppress_filter_posts'] ) {
 		$posts = apply_filters( 'bu_navigation_filter_posts', $posts );
 		$posts = apply_filters( 'bu_navigation_filter_pages', $posts );
 	}
 
 	// Chop off anything great than max_items
-	if ( $r['max_items'] && is_array( $posts ) && ( count( $posts ) > 0 ) ) {
+	if ( $parsed_args['max_items'] && is_array( $posts ) && ( count( $posts ) > 0 ) ) {
 		$items  = array();
 		$nItems = 0;
 
 		foreach ( $posts as $id => $post ) {
-			if ( $nItems >= $r['max_items'] ) {
+			if ( $nItems >= $parsed_args['max_items'] ) {
 				break;
 			}
 			$items[ $id ] = $post;

--- a/includes/library.php
+++ b/includes/library.php
@@ -682,11 +682,12 @@ function bu_navigation_post_types_to_select( $post_types, $include_links ) {
 		$post_types[] = BU_NAVIGATION_LINK_POST_TYPE;
 	}
 
+	// Check the plugin level 'supports' function to see if 'link' type support has been removed.
 	if ( is_object( $bu_navigation_plugin ) && ! $bu_navigation_plugin->supports( 'links' ) ) {
-		$index = array_search( BU_NAVIGATION_LINK_POST_TYPE, $post_types );
-		if ( $index !== false ) {
-			unset( $post_types[ $index ] );
-		}
+		// If so, filter out the link type if it is there.
+		$post_types = array_filter( $post_types, function( $post_type ) {
+			return BU_NAVIGATION_LINK_POST_TYPE !== $post_type;
+		} );
 	}
 
 	return $post_types;

--- a/includes/library.php
+++ b/includes/library.php
@@ -577,7 +577,8 @@ function bu_navigation_get_posts( $args = '' ) {
 	// If the requests post types is 'any', then don't restrict the post type with a where clause.
 	if ( 'any' !== $parsed_args['post_types'] ) {
 		// Otherwise append post types where clause to the SQL query.
-		$post_types_list = bu_navigation_post_types_list( $parsed_args['post_types'], $parsed_args['include_links'] );
+		$post_types_list = bu_navigation_post_types_to_select( $parsed_args['post_types'], $parsed_args['include_links'] );
+		$post_types_list = implode( "','", $post_types_list );
 		$where          .= " AND post_type IN ('$post_types_list')";
 	}
 
@@ -650,7 +651,7 @@ function bu_navigation_get_posts( $args = '' ) {
 }
 
 /**
- * Get a list of post types for inclusion in a database query
+ * Get a list of post types for inclusion in a database select query
  *
  * Given the initial post_types parameter, this checks to see if the link type should be included,
  * also checking the global plugin settings.
@@ -660,9 +661,9 @@ function bu_navigation_get_posts( $args = '' ) {
  * @global object $bu_navigation_plugin
  * @param mixed   $post_types String or array representing all of the post types to be retrieved with the query.
  * @param boolean $include_links Whether or not to include the 'links' post type in the list.
- * @return string Comma delimited list of post types.
+ * @return array Array of post types to include in database query.
  */
-function bu_navigation_post_types_list( $post_types, $include_links ) {
+function bu_navigation_post_types_to_select( $post_types, $include_links ) {
 	global $bu_navigation_plugin;
 
 	if ( is_string( $post_types ) ) {
@@ -685,7 +686,7 @@ function bu_navigation_post_types_list( $post_types, $include_links ) {
 		}
 	}
 
-	return implode( "','", $post_types );
+	return $post_types;
 }
 
 /**

--- a/includes/library.php
+++ b/includes/library.php
@@ -601,19 +601,9 @@ function bu_navigation_get_posts( $args = '' ) {
 		$posts = apply_filters( 'bu_navigation_filter_pages', $posts );
 	}
 
-	// Chop off anything great than max_items
-	if ( $parsed_args['max_items'] && is_array( $posts ) && ( count( $posts ) > 0 ) ) {
-		$items  = array();
-		$nItems = 0;
-
-		foreach ( $posts as $id => $post ) {
-			if ( $nItems >= $parsed_args['max_items'] ) {
-				break;
-			}
-			$items[ $id ] = $post;
-			$nItems++;
-		}
-		$posts = $items;
+	// Chop off anything great than max_items, if set.
+	if ( $parsed_args['max_items'] ) {
+		$posts = array_slice( $posts, 0, $parsed_args['max_items'], true );
 	}
 
 	return $posts;


### PR DESCRIPTION
These changes refactor the get_posts() function (and some related functions) to improve code standards and readability.

Codeclimate scores improve with these changes, but one compromise I have made here is to push harder on adding return statements to unwind complex nested conditionals, as noted for example in this commit: https://github.com/bu-ist/bu-navigation/commit/6ec4ef91489d5a3c4639c12b5c12941fb5e7c7ae

I think it is a practical compromise for this stage of refactoring, as the resulting code scores much better on readability which can help with a further refactoring down the line.  The essential challenge is the amount of branching in how the functions are arranged, which might be addressed with more comprehensive reworking than this particular release.