### PR TITLE
Fix phpunit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,6 @@ cache:
 
 matrix:
   include:
-    - php: 7.4
-      env: WP_VERSION=latest
-    - php: 7.4
-      env: WP_VERSION=5.4.2
     - php: 7.2
       env: WP_VERSION=latest
     - php: 7.2

--- a/class-bu-widget-pages.php
+++ b/class-bu-widget-pages.php
@@ -264,6 +264,7 @@ class BU_Widget_Pages extends WP_Widget {
 			'echo'         => 0,
 			'container_id' => BU_WIDGET_PAGES_LIST_ID,
 			'post_types'   => $post->post_type,
+			'widget'       => true,
 		);
 
 		// Not sure this check is necessary as there should always be an instance style, but leaving it in to preserve original behavior.

--- a/class-bu-widget-pages.php
+++ b/class-bu-widget-pages.php
@@ -264,6 +264,7 @@ class BU_Widget_Pages extends WP_Widget {
 			'echo'         => 0,
 			'container_id' => BU_WIDGET_PAGES_LIST_ID,
 			'post_types'   => $post->post_type,
+			'style'        => $instance['navigation_style'],
 			'widget'       => true,
 		);
 
@@ -272,9 +273,6 @@ class BU_Widget_Pages extends WP_Widget {
 			$GLOBALS['bu_navigation_plugin']->log( 'No nav label widget style set!' );
 			return $list_args;
 		}
-
-		// Include the instance navigation style in the list args.
-		$list_args['style'] = $instance['navigation_style'];
 
 		// 'section' style has special handling.
 		if ( 'section' === $instance['navigation_style'] ) {

--- a/includes/library.php
+++ b/includes/library.php
@@ -1046,6 +1046,7 @@ function bu_navigation_list_pages( $args = '' ) {
 		'title_before'        => '',
 		'title_after'         => '',
 		'style'               => null,
+		'widget'              => false,
 	);
 	$parsed_args = wp_parse_args( $args, $defaults );
 
@@ -1073,7 +1074,7 @@ function bu_navigation_list_pages( $args = '' ) {
 	$pages           = bu_navigation_get_pages( $page_args );
 	$pages_by_parent = bu_navigation_pages_by_parent( $pages );
 
-	if ( 'adaptive' === $parsed_args['style'] ) {
+	if ( $parsed_args['widget'] && 'adaptive' === $parsed_args['style'] ) {
 		$pages_by_parent = bu_navigation_filter_pages_adaptive( $pages_by_parent );
 	}
 

--- a/includes/library.php
+++ b/includes/library.php
@@ -1031,7 +1031,7 @@ function bu_navigation_list_section( $parent_id, $pages_by_parent, $args = '' ) 
  * @return string HTML fragment containing navigation list
  */
 function bu_navigation_list_pages( $args = '' ) {
-	$defaults = array(
+	$defaults    = array(
 		'page_id'             => null,
 		'sections'            => null,
 		'post_types'          => array( 'page' ),


### PR DESCRIPTION
Adds a new parameter to the `list_pages()` args called `widget`.  The adaptive page filter is only _supposed_ to fire when the widget is calling, so the new arg is used to track if the widget is asking for pages.

This distinction is only really apparent from the unit tests. Knowing this now, I'd probably further rename page filter function to clarify that it's only for the widget.  The new arg isn't the cleanest solution, but it's simple and fixes the unit test.

Also includes some minor touch-ups, and removes PHP 7.4 from the travis-ci test matrix until a fix for the phpunit library is available.