### PR TITLE
Various fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "require-dev": {
         "phpunit/phpunit": "4.3.*",
         "codeclimate/php-test-reporter": "dev-master",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
         "squizlabs/php_codesniffer": "3.*",
         "wp-coding-standards/wpcs": "^0.14.0"
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "26ad32a5c38bc84f15c2fd73accc85b4",
+    "content-hash": "1c9863b1d9798373efc31eaea1263593",
     "packages": [],
     "packages-dev": [
         {
@@ -33,6 +33,7 @@
                 "friendsofphp/php-cs-fixer": "^2.0.0",
                 "phpunit/phpunit": "^4.8.35 || ^5.7.0 || ^6.0.0"
             },
+            "default-branch": true,
             "bin": [
                 "composer/bin/test-reporter"
             ],
@@ -64,20 +65,24 @@
                 "codeclimate",
                 "coverage"
             ],
+            "support": {
+                "issues": "https://github.com/codeclimate/php-test-reporter/issues",
+                "source": "https://github.com/codeclimate/php-test-reporter/tree/master"
+            },
             "time": "2018-04-11T15:45:47+00:00"
         },
         {
             "name": "composer/ca-bundle",
-            "version": "1.2.8",
+            "version": "1.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "8a7ecad675253e4654ea05505233285377405215"
+                "reference": "78a0e288fdcebf92aa2318a8d3656168da6ac1a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/8a7ecad675253e4654ea05505233285377405215",
-                "reference": "8a7ecad675253e4654ea05505233285377405215",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/78a0e288fdcebf92aa2318a8d3656168da6ac1a5",
+                "reference": "78a0e288fdcebf92aa2318a8d3656168da6ac1a5",
                 "shasum": ""
             },
             "require": {
@@ -86,14 +91,15 @@
                 "php": "^5.3.2 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 8",
+                "phpstan/phpstan": "^0.12.55",
                 "psr/log": "^1.0",
+                "symfony/phpunit-bridge": "^4.2 || ^5",
                 "symfony/process": "^2.5 || ^3.0 || ^4.0 || ^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.x-dev"
+                    "dev-main": "1.x-dev"
                 }
             },
             "autoload": {
@@ -120,6 +126,11 @@
                 "ssl",
                 "tls"
             ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/ca-bundle/issues",
+                "source": "https://github.com/composer/ca-bundle/tree/1.2.9"
+            },
             "funding": [
                 {
                     "url": "https://packagist.com",
@@ -134,33 +145,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-08-23T12:54:47+00:00"
+            "time": "2021-01-12T12:10:35+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.4.4",
+            "version": "v0.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "2e41850d5f7797cbb1af7b030d245b3b24e63a08"
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/2e41850d5f7797cbb1af7b030d245b3b24e63a08",
-                "reference": "2e41850d5f7797cbb1af7b030d245b3b24e63a08",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/fe390591e0241955f22eb9ba327d137e501c771c",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0",
-                "php": "^5.3|^7",
-                "squizlabs/php_codesniffer": "*"
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
             },
             "require-dev": {
                 "composer/composer": "*",
-                "wimg/php-compatibility": "^8.0"
-            },
-            "suggest": {
-                "dealerdirect/qa-tools": "All the PHP QA tools you'll need"
+                "phpcompatibility/php-compatibility": "^9.0",
+                "sensiolabs/security-checker": "^4.1.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -178,13 +187,13 @@
             "authors": [
                 {
                     "name": "Franck Nijhof",
-                    "email": "f.nijhof@dealerdirect.nl",
-                    "homepage": "http://workingatdealerdirect.eu",
-                    "role": "Developer"
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
-            "homepage": "http://workingatdealerdirect.eu",
+            "homepage": "http://www.dealerdirect.com",
             "keywords": [
                 "PHPCodeSniffer",
                 "PHP_CodeSniffer",
@@ -202,7 +211,11 @@
                 "stylecheck",
                 "tests"
             ],
-            "time": "2017-12-06T16:27:17+00:00"
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2020-12-07T18:04:37+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -253,6 +266,10 @@
                 "constructor",
                 "instantiate"
             ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/1.4.0"
+            },
             "funding": [
                 {
                     "url": "https://www.doctrine-project.org/sponsorship.html",
@@ -359,6 +376,10 @@
                 "rest",
                 "web service"
             ],
+            "support": {
+                "issues": "https://github.com/guzzle/guzzle/issues",
+                "source": "https://github.com/guzzle/guzzle/tree/master"
+            },
             "abandoned": "guzzlehttp/guzzle",
             "time": "2014-01-28T22:29:15+00:00"
         },
@@ -429,6 +450,10 @@
                 "ssl",
                 "tls"
             ],
+            "support": {
+                "issues": "https://github.com/humbug/file_get_contents/issues",
+                "source": "https://github.com/humbug/file_get_contents/tree/master"
+            },
             "time": "2018-02-12T18:47:17+00:00"
         },
         {
@@ -481,6 +506,10 @@
                 "self-update",
                 "update"
             ],
+            "support": {
+                "issues": "https://github.com/humbug/phar-updater/issues",
+                "source": "https://github.com/humbug/phar-updater/tree/1.0"
+            },
             "abandoned": true,
             "time": "2018-03-30T12:52:15+00:00"
         },
@@ -544,6 +573,11 @@
                 "testing",
                 "xunit"
             ],
+            "support": {
+                "irc": "irc://irc.freenode.net/phpunit",
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/2.2"
+            },
             "time": "2015-10-06T15:47:00+00:00"
         },
         {
@@ -589,6 +623,11 @@
                 "filesystem",
                 "iterator"
             ],
+            "support": {
+                "irc": "irc://irc.freenode.net/phpunit",
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/1.3.4"
+            },
             "time": "2013-10-10T15:34:57+00:00"
         },
         {
@@ -630,6 +669,10 @@
             "keywords": [
                 "template"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/1.2.1"
+            },
             "time": "2015-06-21T13:50:34+00:00"
         },
         {
@@ -679,6 +722,10 @@
             "keywords": [
                 "timer"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/master"
+            },
             "time": "2017-02-26T11:10:40+00:00"
         },
         {
@@ -728,6 +775,10 @@
             "keywords": [
                 "tokenizer"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-token-stream/issues",
+                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/1.4"
+            },
             "abandoned": true,
             "time": "2017-12-04T08:55:13+00:00"
         },
@@ -803,6 +854,11 @@
                 "testing",
                 "xunit"
             ],
+            "support": {
+                "irc": "irc://irc.freenode.net/phpunit",
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/4.3"
+            },
             "time": "2014-11-11T10:11:09+00:00"
         },
         {
@@ -859,6 +915,11 @@
                 "mock",
                 "xunit"
             ],
+            "support": {
+                "irc": "irc://irc.freenode.net/phpunit",
+                "issues": "https://github.com/sebastianbergmann/phpunit-mock-objects/issues",
+                "source": "https://github.com/sebastianbergmann/phpunit-mock-objects/tree/2.3"
+            },
             "abandoned": true,
             "time": "2015-10-02T06:51:40+00:00"
         },
@@ -909,6 +970,10 @@
                 "container-interop",
                 "psr"
             ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/master"
+            },
             "time": "2017-02-14T16:28:37+00:00"
         },
         {
@@ -956,6 +1021,9 @@
                 "psr",
                 "psr-3"
             ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/1.1.3"
+            },
             "time": "2020-03-23T09:12:05+00:00"
         },
         {
@@ -1017,6 +1085,10 @@
                 "github",
                 "test"
             ],
+            "support": {
+                "issues": "https://github.com/php-coveralls/php-coveralls/issues",
+                "source": "https://github.com/php-coveralls/php-coveralls/tree/v1.1.0"
+            },
             "abandoned": "php-coveralls/php-coveralls",
             "time": "2017-12-06T23:17:56+00:00"
         },
@@ -1082,6 +1154,10 @@
                 "compare",
                 "equality"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/1.2"
+            },
             "time": "2017-01-29T09:50:25+00:00"
         },
         {
@@ -1134,6 +1210,10 @@
             "keywords": [
                 "diff"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/1.4"
+            },
             "time": "2017-05-22T07:24:03+00:00"
         },
         {
@@ -1184,6 +1264,10 @@
                 "environment",
                 "hhvm"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/1.3"
+            },
             "time": "2016-08-18T05:49:44+00:00"
         },
         {
@@ -1251,6 +1335,10 @@
                 "export",
                 "exporter"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/master"
+            },
             "time": "2016-06-17T09:04:28+00:00"
         },
         {
@@ -1304,6 +1392,10 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/master"
+            },
             "time": "2016-10-03T07:41:43+00:00"
         },
         {
@@ -1339,6 +1431,10 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/1.0.6"
+            },
             "time": "2015-06-21T13:59:46+00:00"
         },
         {
@@ -1390,20 +1486,25 @@
                 "phpcs",
                 "standards"
             ],
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
             "time": "2020-10-23T02:01:07+00:00"
         },
         {
             "name": "symfony/config",
-            "version": "v4.4.16",
+            "version": "v4.4.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "e85481cf359a7b28a44ac91f7d83441b70d76192"
+                "reference": "2c4c7827a7e143f5cf375666641b0f448eab8802"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/e85481cf359a7b28a44ac91f7d83441b70d76192",
-                "reference": "e85481cf359a7b28a44ac91f7d83441b70d76192",
+                "url": "https://api.github.com/repos/symfony/config/zipball/2c4c7827a7e143f5cf375666641b0f448eab8802",
+                "reference": "2c4c7827a7e143f5cf375666641b0f448eab8802",
                 "shasum": ""
             },
             "require": {
@@ -1447,8 +1548,11 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Config Component",
+            "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/config/tree/v4.4.19"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -1463,20 +1567,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T11:50:19+00:00"
+            "time": "2021-01-27T09:09:26+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v4.4.16",
+            "version": "v4.4.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "20f73dd143a5815d475e0838ff867bce1eebd9d5"
+                "reference": "24026c44fc37099fa145707fecd43672831b837a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/20f73dd143a5815d475e0838ff867bce1eebd9d5",
-                "reference": "20f73dd143a5815d475e0838ff867bce1eebd9d5",
+                "url": "https://api.github.com/repos/symfony/console/zipball/24026c44fc37099fa145707fecd43672831b837a",
+                "reference": "24026c44fc37099fa145707fecd43672831b837a",
                 "shasum": ""
             },
             "require": {
@@ -1533,8 +1637,11 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Console Component",
+            "description": "Eases the creation of beautiful and testable command line interfaces",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v4.4.19"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -1549,20 +1656,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T11:50:19+00:00"
+            "time": "2021-01-27T09:09:26+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v4.4.16",
+            "version": "v4.4.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "4204f13d2d0b7ad09454f221bb2195fccdf1fe98"
+                "reference": "c352647244bd376bf7d31efbd5401f13f50dad0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/4204f13d2d0b7ad09454f221bb2195fccdf1fe98",
-                "reference": "4204f13d2d0b7ad09454f221bb2195fccdf1fe98",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/c352647244bd376bf7d31efbd5401f13f50dad0c",
+                "reference": "c352647244bd376bf7d31efbd5401f13f50dad0c",
                 "shasum": ""
             },
             "require": {
@@ -1613,8 +1720,11 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony EventDispatcher Component",
+            "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher/tree/v4.4.19"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -1629,7 +1739,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T11:50:19+00:00"
+            "time": "2021-01-27T09:09:26+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -1691,6 +1801,9 @@
                 "interoperability",
                 "standards"
             ],
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v1.1.9"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -1709,16 +1822,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.1.8",
+            "version": "v5.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "df08650ea7aee2d925380069c131a66124d79177"
+                "reference": "262d033b57c73e8b59cd6e68a45c528318b15038"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/df08650ea7aee2d925380069c131a66124d79177",
-                "reference": "df08650ea7aee2d925380069c131a66124d79177",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/262d033b57c73e8b59cd6e68a45c528318b15038",
+                "reference": "262d033b57c73e8b59cd6e68a45c528318b15038",
                 "shasum": ""
             },
             "require": {
@@ -1748,8 +1861,11 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Filesystem Component",
+            "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v5.2.2"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -1764,20 +1880,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T12:01:57+00:00"
+            "time": "2021-01-27T10:01:46+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.20.0",
+            "version": "v1.22.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41"
+                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f4ba089a5b6366e453971d3aad5fe8e897b37f41",
-                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/c6c942b1ac76c82448322025e084cadc56048b4e",
+                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e",
                 "shasum": ""
             },
             "require": {
@@ -1789,7 +1905,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.20-dev"
+                    "dev-main": "1.22-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -1826,6 +1942,9 @@
                 "polyfill",
                 "portable"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -1840,20 +1959,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-23T14:02:19+00:00"
+            "time": "2021-01-07T16:49:33+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.20.0",
+            "version": "v1.22.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "39d483bdf39be819deabf04ec872eb0b2410b531"
+                "reference": "f377a3dd1fde44d37b9831d68dc8dea3ffd28e13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/39d483bdf39be819deabf04ec872eb0b2410b531",
-                "reference": "39d483bdf39be819deabf04ec872eb0b2410b531",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/f377a3dd1fde44d37b9831d68dc8dea3ffd28e13",
+                "reference": "f377a3dd1fde44d37b9831d68dc8dea3ffd28e13",
                 "shasum": ""
             },
             "require": {
@@ -1865,7 +1984,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.20-dev"
+                    "dev-main": "1.22-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -1903,6 +2022,9 @@
                 "portable",
                 "shim"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.22.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -1917,20 +2039,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-23T14:02:19+00:00"
+            "time": "2021-01-07T16:49:33+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.20.0",
+            "version": "v1.22.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "8ff431c517be11c78c48a39a66d37431e26a6bed"
+                "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/8ff431c517be11c78c48a39a66d37431e26a6bed",
-                "reference": "8ff431c517be11c78c48a39a66d37431e26a6bed",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
+                "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
                 "shasum": ""
             },
             "require": {
@@ -1939,7 +2061,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.20-dev"
+                    "dev-main": "1.22-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -1979,6 +2101,9 @@
                 "portable",
                 "shim"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.22.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -1993,20 +2118,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-23T14:02:19+00:00"
+            "time": "2021-01-07T16:49:33+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.20.0",
+            "version": "v1.22.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "e70aa8b064c5b72d3df2abd5ab1e90464ad009de"
+                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/e70aa8b064c5b72d3df2abd5ab1e90464ad009de",
-                "reference": "e70aa8b064c5b72d3df2abd5ab1e90464ad009de",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dc3063ba22c2a1fd2f45ed856374d79114998f91",
+                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91",
                 "shasum": ""
             },
             "require": {
@@ -2015,7 +2140,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.20-dev"
+                    "dev-main": "1.22-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -2059,6 +2184,9 @@
                 "portable",
                 "shim"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.22.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -2073,7 +2201,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-23T14:02:19+00:00"
+            "time": "2021-01-07T16:49:33+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -2135,6 +2263,9 @@
                 "interoperability",
                 "standards"
             ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/master"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -2153,16 +2284,16 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v4.4.16",
+            "version": "v4.4.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "7c1d1461330e86e901dbb587a10397d15a02cbad"
+                "reference": "c5572f6494fc20668a73b77684d8dc77e534d8cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/7c1d1461330e86e901dbb587a10397d15a02cbad",
-                "reference": "7c1d1461330e86e901dbb587a10397d15a02cbad",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/c5572f6494fc20668a73b77684d8dc77e534d8cf",
+                "reference": "c5572f6494fc20668a73b77684d8dc77e534d8cf",
                 "shasum": ""
             },
             "require": {
@@ -2192,8 +2323,11 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Stopwatch Component",
+            "description": "Provides a way to profile code",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/stopwatch/tree/v4.4.19"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -2208,7 +2342,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T11:50:19+00:00"
+            "time": "2021-01-27T09:09:26+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -2258,6 +2392,9 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v2.8.52"
+            },
             "time": "2018-11-11T11:18:13+00:00"
         },
         {
@@ -2298,6 +2435,11 @@
                 "standards",
                 "wordpress"
             ],
+            "support": {
+                "issues": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki"
+            },
             "time": "2018-02-16T01:57:48+00:00"
         }
     ],
@@ -2310,5 +2452,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/includes/class-navigation-widget.php
+++ b/includes/class-navigation-widget.php
@@ -7,17 +7,8 @@
 
 namespace BU\Plugins\Navigation;
 
-// Default class for list.  UNUSED in the plugin and the BU CMS build.  Should be removed.
-define( 'BU_WIDGET_PAGES_LIST_CLASS', 'smartnav level1' );
-
 // Default element id for list.
 define( 'BU_WIDGET_PAGES_LIST_ID', 'contentnavlist' );
-
-// Default HTML fragment open. UNUSED in the plugin and the BU CMS build.  Should be removed.
-define( 'BU_WIDGET_CONTENTNAV_BEFORE', '<div id="contentnav">' );
-
-// Default HTML fragment close. UNUSED in the plugin and the BU CMS build.  Should be removed.
-define( 'BU_WIDGET_CONTENTNAV_AFTER', '</div>' );
 
 /**
  * Widget for displaying navigation.

--- a/includes/data-model.php
+++ b/includes/data-model.php
@@ -7,6 +7,9 @@
 
 namespace BU\Plugins\Navigation;
 
+// Defines an upper bound for results from direct SQL queries.
+define( 'GROUP_CONCAT_MAX_LEN', 20480 );
+
 /**
  * Returns a complex array that describes the entire navigation tree for the specified post types.
  *

--- a/includes/library.php
+++ b/includes/library.php
@@ -113,25 +113,6 @@ function bu_navigation_get_page_depth( $page_id, $all_sections = null ) {
 }
 
 /**
- * Calculate the post path for a post.
- *
- * Loops backwards from $page through $ancestors to determine full post path.
- * If any ancestor is not present in $ancestors it will attempt to load them on demand.
- * Utilizes static caching to minimize repeat queries across calls.
- *
- * This is a stub for the new namespaced function, but there's no reason to think
- * any other themes or components are calling this. Likely it should be removed.
- *
- * @param  object $page      Post object to query path for. Must contain ID, post_name and post_parent fields.
- * @param  array  $ancestors An array of post objects keyed on post ID.  Should contain ancestors of $page,
- *                           with ID, post_name and post_parent fields for each.
- * @return string            Page path.
- */
-function bu_navigation_get_page_uri( $page, $ancestors ) {
-	return Navigation\get_page_uri( $page, $ancestors );
-}
-
-/**
  * Get the navigation label for a post
  *
  * Content editors set this value through the "Label" text field in the

--- a/includes/library.php
+++ b/includes/library.php
@@ -213,8 +213,8 @@ function bu_navigation_format_page( $page, $args = '' ) {
  *
  * @todo relocate to a default filters file
  *
- * @param $attributes array Associative array of anchor attributes
- * @param $page object Page object
+ * @param array  $classes Associative array of css classes.
+ * @param object $page Page object.
  * @return array Array of classes
  */
 function bu_navigation_filter_item_attrs( $classes, $page ) {

--- a/includes/library.php
+++ b/includes/library.php
@@ -113,26 +113,6 @@ function bu_navigation_get_page_depth( $page_id, $all_sections = null ) {
 }
 
 /**
- * Retrieve the permalink for a post with a custom post type.
- *
- * Intended as an efficient alternative to `get_post_permalink()`.
- * Allows you to provide an array of post ancestors for use calculating post name path.
- *
- * @see `get_post_permalink()`
- *
- * This is a stub for the new namespaced function, but there's no reason to think
- * any other themes or components are calling this. Likely it should be removed.
- *
- * @param  object  $post       Post object to calculate permalink for.
- * @param  array   $ancestors  Optional. An array of post objects keyed on post ID. Should contain all ancestors of $post.
- * @param  boolean $sample     Optional. Is it a sample permalink.
- * @return string              Post permalink.
- */
-function bu_navigation_get_post_link( $post, $ancestors = array(), $sample = false ) {
-	return Navigation\get_nav_post_link( $post, $ancestors, $sample );
-}
-
-/**
  * Calculate the post path for a post.
  *
  * Loops backwards from $page through $ancestors to determine full post path.

--- a/includes/library.php
+++ b/includes/library.php
@@ -19,7 +19,6 @@ if ( defined( 'BU_NAVIGATION_LIB_LOADED' ) && BU_NAVIGATION_LIB_LOADED ) {
 
 define( 'BU_NAVIGATION_LIB_LOADED', true );
 
-define( 'GROUP_CONCAT_MAX_LEN', 20480 );
 
 /**
  * Gets the supported post_types by the bu-navigation plugin.

--- a/includes/library.php
+++ b/includes/library.php
@@ -113,26 +113,6 @@ function bu_navigation_get_page_depth( $page_id, $all_sections = null ) {
 }
 
 /**
- * Retrieve the page permalink.
- *
- * Intended as an efficient alternative to `get_page_link()` / `_get_page_link()`.
- * Allows you to provide an array of post ancestors for use calculating post name path.
- *
- * This is a stub for the new namespaced function, but there's no reason to think
- * any other themes or components are calling this. Likely it should be removed.
- *
- * @see `_get_page_link()`
- *
- * @param  object  $page       Post object to calculate permalink for.
- * @param  array   $ancestors  Optional. An array of post objects keyed on post ID. Should contain all ancestors of $page.
- * @param  boolean $sample     Optional. Is it a sample permalink.
- * @return string              Post permalink.
- */
-function bu_navigation_get_page_link( $page, $ancestors = array(), $sample = false ) {
-	return Navigation\get_nav_page_link( $page, $ancestors, $sample );
-}
-
-/**
  * Retrieve the permalink for a post with a custom post type.
  *
  * Intended as an efficient alternative to `get_post_permalink()`.

--- a/includes/library.php
+++ b/includes/library.php
@@ -113,26 +113,6 @@ function bu_navigation_get_page_depth( $page_id, $all_sections = null ) {
 }
 
 /**
- * Add the post permalink as a property on the post object.
- *
- * Helpful when you need URLs for a large number of posts and don't want to
- * melt your server with 3000 calls to `get_permalink()`.
- *
- * This is most efficient when $pages contains the complete ancestry for each post. If any post
- * ancestors are missing when calculating hierarchical post names it will load them,
- * at the expensive of a few extra queries.
- *
- * This is a stub for the new namespaced function, but there's no reason to think
- * any other themes or components are calling this. Likely it should be removed.
- *
- * @param  array $pages An array of post objects keyed on post ID. Works with all post types.
- * @return array $pages The input array with $post->url set to the permalink for each post.
- */
-function bu_navigation_get_urls( $pages ) {
-	return Navigation\get_urls( $pages );
-}
-
-/**
  * Retrieve the page permalink.
  *
  * Intended as an efficient alternative to `get_page_link()` / `_get_page_link()`.

--- a/includes/library.php
+++ b/includes/library.php
@@ -93,22 +93,6 @@ function bu_navigation_gather_sections( $page_id, $args = '', $all_sections = nu
 }
 
 /**
- * Gets a section of children given a post ID and some arguments.
- *
- * This is a stub for the new namespaced function, but there's no reason to think
- * any other themes or components are calling this. Likely it should be removed.
- *
- * @param string  $parent_id ID of a parent post expressed as a string.
- * @param array   $sections All of the sections at the depth being gathered.
- * @param integer $max_depth Maximum depth to gather.
- * @param integer $current_depth Current depth from gather_sections() args.
- * @return array Array of page ids.
- */
-function bu_navigation_gather_childsections( $parent_id, $sections, $max_depth = 0, $current_depth = 1 ) {
-	return Navigation\gather_childsections( $parent_id, $sections, $max_depth, $current_depth );
-}
-
-/**
  * This is the only function that appears to allow for the the 3rd 'all_sections' arg from gather_sections.
  * It is entirely unusued at BU except for the bu-tech-workflow.php template in the bu-tech-2014 theme.
  * Ideally this function should be deprecated, and the 'all_sections' arg should be removed from gather_sections.

--- a/tests/phpunit/test-library.php
+++ b/tests/phpunit/test-library.php
@@ -438,10 +438,10 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 
 			// With ancestors
 			$ancestors = bu_navigation_gather_sections( $grandchild->ID, array( 'direction' => 'up' ) );
-			$this->assertEquals( get_post_permalink( $grandchild ), bu_navigation_get_post_link( $grandchild, $ancestors ) );
+			$this->assertEquals( get_post_permalink( $grandchild ), Navigation\get_nav_post_link( $grandchild, $ancestors ) );
 
 			// Without ancestors
-			$this->assertEquals( get_post_permalink( $grandchild ), bu_navigation_get_post_link( $grandchild ) );
+			$this->assertEquals( get_post_permalink( $grandchild ), Navigation\get_nav_post_link( $grandchild ) );
 		}
 	}
 
@@ -461,18 +461,18 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		$pending_child = get_post( $pending_child );
 
 		// Root unpublished
-		$this->assertEquals( get_post_permalink( $draft ), bu_navigation_get_post_link( $draft ) );
-		$this->assertEquals( get_post_permalink( $pending ), bu_navigation_get_post_link( $pending ) );
+		$this->assertEquals( get_post_permalink( $draft ), Navigation\get_nav_post_link( $draft ) );
+		$this->assertEquals( get_post_permalink( $pending ), Navigation\get_nav_post_link( $pending ) );
 
 		// Public parent, unpublished children
-		$this->assertEquals( get_post_permalink( $draft_child ), bu_navigation_get_post_link( $draft_child ) );
-		$this->assertEquals( get_post_permalink( $pending_child ), bu_navigation_get_post_link( $pending_child ) );
+		$this->assertEquals( get_post_permalink( $draft_child ), Navigation\get_nav_post_link( $draft_child ) );
+		$this->assertEquals( get_post_permalink( $pending_child ), Navigation\get_nav_post_link( $pending_child ) );
 
 		// Sample permalinks for unpublished posts
-		$this->assertEquals( get_post_permalink( $draft, false, true ), bu_navigation_get_post_link( $draft, array(), true ) );
-		$this->assertEquals( get_post_permalink( $draft_child, false, true ), bu_navigation_get_post_link( $draft_child, array(), true ) );
-		$this->assertEquals( get_post_permalink( $pending, false, true ), bu_navigation_get_post_link( $pending, array(), true ) );
-		$this->assertEquals( get_post_permalink( $pending_child, false, true ), bu_navigation_get_post_link( $pending_child, array(), true ) );
+		$this->assertEquals( get_post_permalink( $draft, false, true ), Navigation\get_nav_post_link( $draft, array(), true ) );
+		$this->assertEquals( get_post_permalink( $draft_child, false, true ), Navigation\get_nav_post_link( $draft_child, array(), true ) );
+		$this->assertEquals( get_post_permalink( $pending, false, true ), Navigation\get_nav_post_link( $pending, array(), true ) );
+		$this->assertEquals( get_post_permalink( $pending_child, false, true ), Navigation\get_nav_post_link( $pending_child, array(), true ) );
 	}
 
 	/**
@@ -506,8 +506,8 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		wp_update_post($public_pending_child);
 
 		// Draft parent, public children
-		$this->assertEquals( get_post_permalink( $public_draft_child ), bu_navigation_get_post_link( $public_draft_child ) );
-		$this->assertEquals( get_post_permalink( $public_pending_child ), bu_navigation_get_post_link( $public_pending_child ) );
+		$this->assertEquals( get_post_permalink( $public_draft_child ), Navigation\get_nav_post_link( $public_draft_child ) );
+		$this->assertEquals( get_post_permalink( $public_pending_child ), Navigation\get_nav_post_link( $public_pending_child ) );
 	}
 
 	public function test_bu_navigation_get_post_link_no_permalinks() {
@@ -537,9 +537,9 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		$cpt_two = get_post( $cpt_two );
 		$cpt_three = get_post( $cpt_three );
 
-		$this->assertEquals( get_post_permalink( $cpt_one ), bu_navigation_get_post_link( $cpt_one ) );
-		$this->assertEquals( get_post_permalink( $cpt_two ), bu_navigation_get_post_link( $cpt_two ) );
-		$this->assertEquals( get_post_permalink( $cpt_three ), bu_navigation_get_post_link( $cpt_three ) );
+		$this->assertEquals( get_post_permalink( $cpt_one ), Navigation\get_nav_post_link( $cpt_one ) );
+		$this->assertEquals( get_post_permalink( $cpt_two ), Navigation\get_nav_post_link( $cpt_two ) );
+		$this->assertEquals( get_post_permalink( $cpt_three ), Navigation\get_nav_post_link( $cpt_three ) );
 	}
 
 	/**

--- a/tests/phpunit/test-library.php
+++ b/tests/phpunit/test-library.php
@@ -338,7 +338,7 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		unset( $pages[$test_child]->url );
 
 		// Use get_urls to get the new url
-		$pages = bu_navigation_get_urls( $pages );
+		$pages = Navigation\get_urls( $pages );
 
 		// Test to make sure the url is the expected one
 		$this->assertEquals( get_permalink($parent), $pages[$parent]->url );

--- a/tests/phpunit/test-library.php
+++ b/tests/phpunit/test-library.php
@@ -1,5 +1,7 @@
 <?php
 
+use BU\Plugins\Navigation as Navigation;
+
 /**
  * Coverage for functions in the BU Navigation library
  *
@@ -170,7 +172,7 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		$good_childsections = false;
 
 		// $parent should return child and grandchild_one as the only sections
-		$child_sections = bu_navigation_gather_childsections( $parent, $all_sections['sections'] );
+		$child_sections = Navigation\gather_childsections( $parent, $all_sections['sections'] );
 		if( count( $child_sections ) == 2 and
 			$child_sections[0] == $child  and
 			$child_sections[1] == $grandchild_one )
@@ -179,8 +181,8 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		$this->assertTrue( $good_childsections );
 
 		// Test Depth Functionality
-		$depth_one = bu_navigation_gather_childsections( $parent, $all_sections['sections'], 1 );
-		$depth_two = bu_navigation_gather_childsections( $parent, $all_sections['sections'], 2 );
+		$depth_one = Navigation\gather_childsections( $parent, $all_sections['sections'], 1 );
+		$depth_two = Navigation\gather_childsections( $parent, $all_sections['sections'], 2 );
 
 		// Expected results
 		$depth_one_exp = array( $child );

--- a/tests/phpunit/test-library.php
+++ b/tests/phpunit/test-library.php
@@ -370,15 +370,15 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 
 		// With ancestors
 		$ancestors = bu_navigation_gather_sections( $grandchild->ID, array( 'direction' => 'up' ) );
-		$this->assertEquals( get_page_link( $grandchild ), bu_navigation_get_page_link( $grandchild, $ancestors ) );
+		$this->assertEquals( get_page_link( $grandchild ), Navigation\get_nav_page_link( $grandchild, $ancestors ) );
 
 		// Without ancestors
-		$this->assertEquals( get_page_link( $grandchild ), bu_navigation_get_page_link( $grandchild ) );
+		$this->assertEquals( get_page_link( $grandchild ), Navigation\get_nav_page_link( $grandchild ) );
 
 		// Page on front
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_on_front', $grandchild->ID );
-		$this->assertEquals( get_page_link( $grandchild ), bu_navigation_get_page_link( $grandchild ) );
+		$this->assertEquals( get_page_link( $grandchild ), Navigation\get_nav_page_link( $grandchild ) );
 	}
 
 	public function test_bu_navigation_get_page_link_unpublished() {
@@ -399,22 +399,22 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		$public_pending_child = get_post( $public_pending_child );
 
 		// Root unpublished
-		$this->assertEquals( get_page_link( $draft ), bu_navigation_get_page_link( $draft ) );
-		$this->assertEquals( get_page_link( $pending ), bu_navigation_get_page_link( $pending ) );
+		$this->assertEquals( get_page_link( $draft ), Navigation\get_nav_page_link( $draft ) );
+		$this->assertEquals( get_page_link( $pending ), Navigation\get_nav_page_link( $pending ) );
 
 		// Public parent, unpublished children
-		$this->assertEquals( get_page_link( $draft_child ), bu_navigation_get_page_link( $draft_child ) );
-		$this->assertEquals( get_page_link( $pending_child ), bu_navigation_get_page_link( $pending_child ) );
+		$this->assertEquals( get_page_link( $draft_child ), Navigation\get_nav_page_link( $draft_child ) );
+		$this->assertEquals( get_page_link( $pending_child ), Navigation\get_nav_page_link( $pending_child ) );
 
 		// Draft parent, public children
-		$this->assertEquals( get_page_link( $public_draft_child ), bu_navigation_get_page_link( $public_draft_child ) );
-		$this->assertEquals( get_page_link( $public_pending_child ), bu_navigation_get_page_link( $public_pending_child ) );
+		$this->assertEquals( get_page_link( $public_draft_child ), Navigation\get_nav_page_link( $public_draft_child ) );
+		$this->assertEquals( get_page_link( $public_pending_child ), Navigation\get_nav_page_link( $public_pending_child ) );
 
 		// Sample permalinks for unpublished pages
-		$this->assertEquals( get_page_link( $draft, false, true ), bu_navigation_get_page_link( $draft, array(), true ) );
-		$this->assertEquals( get_page_link( $draft_child, false, true ), bu_navigation_get_page_link( $draft_child, array(), true ) );
-		$this->assertEquals( get_page_link( $pending, false, true ), bu_navigation_get_page_link( $pending, array(), true ) );
-		$this->assertEquals( get_page_link( $pending_child, false, true ), bu_navigation_get_page_link( $pending_child, array(), true ) );
+		$this->assertEquals( get_page_link( $draft, false, true ), Navigation\get_nav_page_link( $draft, array(), true ) );
+		$this->assertEquals( get_page_link( $draft_child, false, true ), Navigation\get_nav_page_link( $draft_child, array(), true ) );
+		$this->assertEquals( get_page_link( $pending, false, true ), Navigation\get_nav_page_link( $pending, array(), true ) );
+		$this->assertEquals( get_page_link( $pending_child, false, true ), Navigation\get_nav_page_link( $pending_child, array(), true ) );
 	}
 
 	public function test_bu_navigation_get_page_link_no_permalinks() {


### PR DESCRIPTION
- Removes stub declarations for functions that aren't used outside the plugin (at least at BU).  This is a potentially breaking change in the unlikely event that anyone outside BU is calling these global functions directly.  The next release with this change should probably be 1.3.0 to reflect the change.
- Removes some unused constants
- Updates composer dependencies in order to work with Composer 2.
- Moves a constant closer to where it is used, and adjusts some inline docs.