### PR TITLE
Phpunit tests code formatting

### DIFF
--- a/tests/phpunit/nav-testcase.php
+++ b/tests/phpunit/nav-testcase.php
@@ -30,10 +30,9 @@ class BU_Navigation_UnitTestCase extends WP_UnitTestCase {
 			if ( is_array( $data ) && ! empty( $data ) ) {
 				return call_user_func( array( $this, "load_test_$type" ), $data );
 			}
-
 		}
 
-		$this->fail("Error loading fixture: $path");
+		$this->fail( "Error loading fixture: $path" );
 
 	}
 
@@ -44,25 +43,26 @@ class BU_Navigation_UnitTestCase extends WP_UnitTestCase {
 	 * Handles
 	 *  - all post fields (through the "data" attribute)
 	 *  - post meta data (by specifying "metakey" => "value" for the "metadata" attribute)
-	 * 	- hierarchical posts (by nesting post data in the "children" attribute)
+	 *  - hierarchical posts (by nesting post data in the "children" attribute)
 	 *
 	 * Each post should be given a unique key, which will be used to store the post ID
 	 * for reference during tests.
 	 *
 	 * See the file for an example:
-	 * 	tests/fixtures/posts.json
+	 *  tests/fixtures/posts.json
 	 */
 	public function load_test_posts( $data, $parent_id = 0 ) {
 
 		$posts = array();
 
-		foreach( $data as $key => $post ) {
+		foreach ( $data as $key => $post ) {
 
 			$data = $post['data'];
 
 			// Maybe set parent
-			if( $parent_id )
+			if ( $parent_id ) {
 				$data['post_parent'] = $parent_id;
+			}
 
 			// Create post
 			$id = $this->factory->post->create( $data );
@@ -70,20 +70,20 @@ class BU_Navigation_UnitTestCase extends WP_UnitTestCase {
 			// Add any post meta
 			$metadata = $post['metadata'];
 
-			if( !empty( $metadata ) ) {
-				foreach( $metadata as $meta_key => $meta_val ) {
+			if ( ! empty( $metadata ) ) {
+				foreach ( $metadata as $meta_key => $meta_val ) {
 					update_post_meta( $id, $meta_key, $meta_val );
 				}
 			}
 
 			// Load children
 			$children = $post['children'];
-			if( ! empty( $children ) ) {
+			if ( ! empty( $children ) ) {
 				$posts = array_merge( $posts, $this->load_test_posts( $children, $id ) );
 			}
 
 			// Cache internally for access during tests
-			$posts[$key] = $id;
+			$posts[ $key ] = $id;
 
 		}
 
@@ -97,21 +97,22 @@ class BU_Navigation_UnitTestCase extends WP_UnitTestCase {
 	 * @requires BU Section Editing plugin
 	 */
 	public function generate_section_group() {
-		if ( ! is_plugin_active( 'bu-section-editing/bu-section-editing.php' ) )
+		if ( ! is_plugin_active( 'bu-section-editing/bu-section-editing.php' ) ) {
 			return;
+		}
 
-		$section_editor = $this->factory->user->create(array('role'=>'section_editor'));
+		$section_editor                = $this->factory->user->create( array( 'role' => 'section_editor' ) );
 		$this->users['section_editor'] = $section_editor;
 
 		$allowed = array( $this->posts['child'], $this->posts['grandchild_one'], $this->posts['grandchild_two'] );
 
 		$groupdata = array(
-			'name' => 'Test group',
+			'name'        => 'Test group',
 			'description' => 'Test description',
-			'users' => array($this->users['section_editor']),
-			'perms' => array(
-				'page' => array( 'allowed' => $allowed )
-			)
+			'users'       => array( $this->users['section_editor'] ),
+			'perms'       => array(
+				'page' => array( 'allowed' => $allowed ),
+			),
 		);
 
 		$group = BU_Edit_Groups::get_instance()->add_group( $groupdata );

--- a/tests/phpunit/test-admin-manager.php
+++ b/tests/phpunit/test-admin-manager.php
@@ -27,16 +27,17 @@ class Test_BU_Navigation_Admin_Manager extends BU_Navigation_UnitTestCase {
 
 		// Setup users
 		$this->users = array(
-			'admin' => $this->factory->user->create(array('role'=>'administrator')),
-			'contrib' => $this->factory->user->create(array('role'=>'contributor'))
-			);
+			'admin'   => $this->factory->user->create( array( 'role' => 'administrator' ) ),
+			'contrib' => $this->factory->user->create( array( 'role' => 'contributor' ) ),
+		);
 
 		// Setup posts
 		$this->posts = $this->load_fixture( 'posts' );
 
 		// Requires the BU Section Editing plugin to be activated
-		if ( is_plugin_active( 'bu-section-editing/bu-section-editing.php' ) )
+		if ( is_plugin_active( 'bu-section-editing/bu-section-editing.php' ) ) {
 			$this->generate_section_group();
+		}
 
 	}
 
@@ -47,12 +48,11 @@ class Test_BU_Navigation_Admin_Manager extends BU_Navigation_UnitTestCase {
 		$this->assertTrue( $this->navman->can_publish_top_level() );
 
 		// Don't allow top level posts
-		$this->plugin->settings->update(array('allow_top'=>false));
+		$this->plugin->settings->update( array( 'allow_top' => false ) );
 
 		$this->assertFalse( $this->navman->can_publish_top_level() );
 
 		// @todo section editor integration
-
 	}
 
 	public function test_can_place_in_section() {
@@ -66,7 +66,7 @@ class Test_BU_Navigation_Admin_Manager extends BU_Navigation_UnitTestCase {
 		$this->assertTrue( $this->navman->can_place_in_section( $gc_one, $this->posts['child'] ) );
 
 		// Don't allow top level posts
-		$this->plugin->settings->update(array('allow_top'=>false));
+		$this->plugin->settings->update( array( 'allow_top' => false ) );
 
 		$gc_one->post_parent = 0;
 		$this->assertFalse( $this->navman->can_place_in_section( $gc_one, $this->posts['child'] ) );
@@ -77,16 +77,17 @@ class Test_BU_Navigation_Admin_Manager extends BU_Navigation_UnitTestCase {
 		$this->assertTrue( $this->navman->can_place_in_section( $gc_one, 0 ) );
 
 		// Re-allow top level posts
-		$this->plugin->settings->update(array('allow_top'=>true));
+		$this->plugin->settings->update( array( 'allow_top' => true ) );
 
 		// Coverage for section editor logic
-		if ( ! is_plugin_active( 'bu-section-editing/bu-section-editing.php' ) )
+		if ( ! is_plugin_active( 'bu-section-editing/bu-section-editing.php' ) ) {
 			return;
+		}
 
 		wp_set_current_user( $this->users['section_editor'] );
 
 		// Simulate move to top level
-		$post = get_post( $this->posts['grandchild_one'] );
+		$post              = get_post( $this->posts['grandchild_one'] );
 		$post->post_parent = 0;
 
 		// Top level moves deneid, regardless of allow top setting or previously in navigation condition
@@ -108,7 +109,7 @@ class Test_BU_Navigation_Admin_Manager extends BU_Navigation_UnitTestCase {
 		wp_set_current_user( $this->users['admin'] );
 
 		// Simulate move to top level
-		$post = get_post( $this->posts['grandchild_one'] );
+		$post     = get_post( $this->posts['grandchild_one'] );
 		$original = clone $post;
 
 		$post->post_parent = 0;
@@ -120,7 +121,7 @@ class Test_BU_Navigation_Admin_Manager extends BU_Navigation_UnitTestCase {
 		$this->assertTrue( $this->navman->can_move( $post, $original->ID ) );
 
 		// Don't allow top level posts
-		$this->plugin->settings->update(array('allow_top'=>false));
+		$this->plugin->settings->update( array( 'allow_top' => false ) );
 		$this->assertFalse( $this->navman->can_move( $post, $original ) );
 
 		// Fake original location was top level
@@ -128,7 +129,6 @@ class Test_BU_Navigation_Admin_Manager extends BU_Navigation_UnitTestCase {
 		$this->assertTrue( $this->navman->can_move( $post, $original ) );
 
 		// @todo section editor integration
-
 	}
 
 	public function test_can_move_contrib() {
@@ -136,7 +136,7 @@ class Test_BU_Navigation_Admin_Manager extends BU_Navigation_UnitTestCase {
 		wp_set_current_user( $this->users['contrib'] );
 
 		// Simulate move to top level
-		$post = get_post( $this->posts['grandchild_one'] );
+		$post     = get_post( $this->posts['grandchild_one'] );
 		$original = clone $post;
 
 		$post->post_parent = 0;
@@ -148,7 +148,7 @@ class Test_BU_Navigation_Admin_Manager extends BU_Navigation_UnitTestCase {
 		$this->assertFalse( $this->navman->can_move( $post, $original->ID ) );
 
 		// Don't allow top level posts
-		$this->plugin->settings->update(array('allow_top'=>false));
+		$this->plugin->settings->update( array( 'allow_top' => false ) );
 		$this->assertFalse( $this->navman->can_move( $post, $original ) );
 
 		// Fake original location was top level
@@ -156,7 +156,6 @@ class Test_BU_Navigation_Admin_Manager extends BU_Navigation_UnitTestCase {
 		$this->assertFalse( $this->navman->can_move( $post, $original ) );
 
 		// @todo section editor integration
-
 	}
 
 	public function test_process_deletions() {
@@ -177,7 +176,6 @@ class Test_BU_Navigation_Admin_Manager extends BU_Navigation_UnitTestCase {
 		$this->assertNull( $deleted_link );
 
 		// @todo section editor integration
-
 	}
 
 	public function test_process_deletions_contrib() {
@@ -198,7 +196,6 @@ class Test_BU_Navigation_Admin_Manager extends BU_Navigation_UnitTestCase {
 		$this->assertEquals( 'publish', $deleted_link->post_status );
 
 		// @todo section editor integration
-
 	}
 
 	public function test_process_insertions() {
@@ -206,36 +203,38 @@ class Test_BU_Navigation_Admin_Manager extends BU_Navigation_UnitTestCase {
 		wp_set_current_user( $this->users['admin'] );
 
 		$link1 = array(
-			'ID' => 'post-new-0',
-			'post_title' => 'Example Link 1',
-			'post_type' => 'bu_link',
+			'ID'           => 'post-new-0',
+			'post_title'   => 'Example Link 1',
+			'post_type'    => 'bu_link',
 			'post_content' => 'http://www.example.com',
-			'post_status' => 'publish',
-			'post_meta' => (object) array( 'bu_link_target' => 'new' ),
-			'post_parent' => 0,
-			'menu_order' => 1
-			);
+			'post_status'  => 'publish',
+			'post_meta'    => (object) array( 'bu_link_target' => 'new' ),
+			'post_parent'  => 0,
+			'menu_order'   => 1,
+		);
 
 		$link2 = array(
-			'ID' => 'post-new-1',
-			'post_title' => 'Example Link 2',
-			'post_type' => 'bu_link',
+			'ID'           => 'post-new-1',
+			'post_title'   => 'Example Link 2',
+			'post_type'    => 'bu_link',
 			'post_content' => 'http://www.example2.com',
-			'post_status' => 'publish',
-			'post_meta' => (object) array( 'bu_link_target' => 'same' ),
-			'post_parent' => $this->posts['child'],
-			'menu_order' => 1
-			);
+			'post_status'  => 'publish',
+			'post_meta'    => (object) array( 'bu_link_target' => 'same' ),
+			'post_parent'  => $this->posts['child'],
+			'menu_order'   => 1,
+		);
 
 		// array of post objects to insert
-		$insertions = array( 'post-new-0' => (object) $link1, 'post-new-1' => (object) $link2 );
+		$insertions = array(
+			'post-new-0' => (object) $link1,
+			'post-new-1' => (object) $link2,
+		);
 
 		$result = $this->navman->process_insertions( $insertions );
 
 		$this->assertTrue( $result );
 
 		// @todo get newly created links by title
-
 		// @todo section editor integration
 	}
 
@@ -245,13 +244,13 @@ class Test_BU_Navigation_Admin_Manager extends BU_Navigation_UnitTestCase {
 
 		$updates = array(
 			$this->posts['google'] => (object) array(
-				'ID' => $this->posts['google'],
-				'post_title' => 'Bing',
-				'post_type' => 'bu_link',
+				'ID'           => $this->posts['google'],
+				'post_title'   => 'Bing',
+				'post_type'    => 'bu_link',
 				'post_content' => 'http://www.bing.com',
-				'post_meta' => (object) array( 'bu_link_target' => 'same' ),
-				)
-			);
+				'post_meta'    => (object) array( 'bu_link_target' => 'same' ),
+			),
+		);
 
 		$result = $this->navman->process_updates( $updates );
 
@@ -274,35 +273,35 @@ class Test_BU_Navigation_Admin_Manager extends BU_Navigation_UnitTestCase {
 
 		$moves = array(
 			$this->posts['hidden'] => (object) array(
-				'ID' => $this->posts['hidden'],
-				'post_type' => 'page',
+				'ID'          => $this->posts['hidden'],
+				'post_type'   => 'page',
 				'post_status' => 'publish',
 				'post_parent' => $this->posts['child'],
-				'menu_order' => 1
-				),
-			$this->posts['child'] => (object) array(
-				'ID' => $this->posts['child'],
-				'post_type' => 'page',
+				'menu_order'  => 1,
+			),
+			$this->posts['child']  => (object) array(
+				'ID'          => $this->posts['child'],
+				'post_type'   => 'page',
 				'post_status' => 'publish',
 				'post_parent' => 0,
-				'menu_order' => 2
-				),
-			$this->posts['edit'] => (object) array(
-				'ID' => $this->posts['edit'],
-				'post_type' => 'page',
+				'menu_order'  => 2,
+			),
+			$this->posts['edit']   => (object) array(
+				'ID'          => $this->posts['edit'],
+				'post_type'   => 'page',
 				'post_status' => 'publish',
 				'post_parent' => $this->posts['last_page'],
-				'menu_order' => 1
-				)
-			);
+				'menu_order'  => 1,
+			),
+		);
 
 		$result = $this->navman->process_moves( $moves );
 
 		$this->assertTrue( $result );
 
 		$hidden = get_post( $this->posts['hidden'] );
-		$child = get_post( $this->posts['child'] );
-		$edit = get_post( $this->posts['edit'] );
+		$child  = get_post( $this->posts['child'] );
+		$edit   = get_post( $this->posts['edit'] );
 
 		$this->assertEquals( $this->posts['child'], $hidden->post_parent );
 		$this->assertEquals( 1, $hidden->menu_order );
@@ -326,28 +325,38 @@ class Test_BU_Navigation_Admin_Manager extends BU_Navigation_UnitTestCase {
 		wp_set_current_user( $this->users['admin'] );
 
 		// Construct moves $_POST array from JSON file
-		$updates = $this->load_manager_post( dirname(__FILE__) . '/fixtures/manager_post.json' );
+		$updates = $this->load_manager_post( dirname( __FILE__ ) . '/fixtures/manager_post.json' );
 
-		$_POST['bu_navman_save'] = 'Publish Changes';
-		$_POST['navman-moves'] = json_encode($updates['navman-moves']);
-		$_POST['navman-inserts'] = json_encode($updates['navman-inserts']);
-		$_POST['navman-updates'] = json_encode($updates['navman-updates']);
-		$_POST['navman-deletions'] = json_encode($updates['navman-deletions']);
+		$_POST['bu_navman_save']   = 'Publish Changes';
+		$_POST['navman-moves']     = json_encode( $updates['navman-moves'] );
+		$_POST['navman-inserts']   = json_encode( $updates['navman-inserts'] );
+		$_POST['navman-updates']   = json_encode( $updates['navman-updates'] );
+		$_POST['navman-deletions'] = json_encode( $updates['navman-deletions'] );
 
 		// Run the save
 		$this->navman->save();
 
 		// Inserts
-		$links = get_posts(array('s'=>'New Link','post_type'=>'bu_link'));
-		$new_link = array_pop($links);
+		$links    = get_posts(
+			array(
+				's'         => 'New Link',
+				'post_type' => 'bu_link',
+			)
+		);
+		$new_link = array_pop( $links );
 		$this->assertEquals( 'New Link', $new_link->post_title );
 		$this->assertEquals( 'http://newlink.com', $new_link->post_content );
 		$this->assertEquals( $this->posts['last_page'], $new_link->post_parent );
 		$this->assertEquals( 1, $new_link->menu_order );
 		$this->assertEquals( 'new', get_post_meta( $new_link->ID, 'bu_link_target', true ) );
 
-		$links = get_posts(array('s'=>'Top Level Link','post_type'=>'bu_link'));
-		$new_link_two = array_pop($links);
+		$links        = get_posts(
+			array(
+				's'         => 'Top Level Link',
+				'post_type' => 'bu_link',
+			)
+		);
+		$new_link_two = array_pop( $links );
 		$this->assertEquals( 'Top Level Link', $new_link_two->post_title );
 		$this->assertEquals( 'http://toplevel.com', $new_link_two->post_content );
 		$this->assertEquals( 0, $new_link_two->post_parent );
@@ -355,29 +364,29 @@ class Test_BU_Navigation_Admin_Manager extends BU_Navigation_UnitTestCase {
 		$this->assertEquals( 'same', get_post_meta( $new_link_two->ID, 'bu_link_target', true ) );
 
 		// Updates
-		$this->assertEquals( 'Bing', get_post($this->posts['google'])->post_title );
-		$this->assertEquals( 'http://www.bing.com', get_post($this->posts['google'])->post_content );
-		$this->assertEquals( 'same', get_post_meta($this->posts['google'], 'bu_link_target', true ) );
+		$this->assertEquals( 'Bing', get_post( $this->posts['google'] )->post_title );
+		$this->assertEquals( 'http://www.bing.com', get_post( $this->posts['google'] )->post_content );
+		$this->assertEquals( 'same', get_post_meta( $this->posts['google'], 'bu_link_target', true ) );
 
 		// Deletions
-		$this->assertEquals( 'trash', get_post($this->posts['hidden'])->post_status );
+		$this->assertEquals( 'trash', get_post( $this->posts['hidden'] )->post_status );
 
 		// Moves
-		$this->assertEquals( 0, get_post($this->posts['grandchild_one'])->post_parent);
-		$this->assertEquals( 1, get_post($this->posts['grandchild_one'])->menu_order);
-		$this->assertEquals( $this->posts['child'], get_post($this->posts['edit'])->post_parent);
-		$this->assertEquals( 1, get_post($this->posts['edit'])->menu_order);
+		$this->assertEquals( 0, get_post( $this->posts['grandchild_one'] )->post_parent );
+		$this->assertEquals( 1, get_post( $this->posts['grandchild_one'] )->menu_order );
+		$this->assertEquals( $this->posts['child'], get_post( $this->posts['edit'] )->post_parent );
+		$this->assertEquals( 1, get_post( $this->posts['edit'] )->menu_order );
 
 		// Reordering
-		$this->assertEquals( 1, get_post($this->posts['grandchild_one'])->menu_order);
-		$this->assertEquals( 2, get_post($this->posts['parent'])->menu_order);
-		$this->assertEquals( 3, get_post($this->posts['private'])->menu_order);
+		$this->assertEquals( 1, get_post( $this->posts['grandchild_one'] )->menu_order );
+		$this->assertEquals( 2, get_post( $this->posts['parent'] )->menu_order );
+		$this->assertEquals( 3, get_post( $this->posts['private'] )->menu_order );
 		/* new link two should be 4 */
-		$this->assertEquals( 5, get_post($this->posts['google'])->menu_order);
-		$this->assertEquals( 6, get_post($this->posts['last_page'])->menu_order);
+		$this->assertEquals( 5, get_post( $this->posts['google'] )->menu_order );
+		$this->assertEquals( 6, get_post( $this->posts['last_page'] )->menu_order );
 
-		$this->assertEquals( 1, get_post($this->posts['edit'])->menu_order);
-		$this->assertEquals( 2, get_post($this->posts['grandchild_two'])->menu_order);
+		$this->assertEquals( 1, get_post( $this->posts['edit'] )->menu_order );
+		$this->assertEquals( 2, get_post( $this->posts['grandchild_two'] )->menu_order );
 
 	}
 
@@ -389,52 +398,53 @@ class Test_BU_Navigation_Admin_Manager extends BU_Navigation_UnitTestCase {
 	 * post ID's by the keys used in $this->posts.
 	 *
 	 * For instance:
-	 * 	%grandchild_one% => $this->posts['grandchild_one']
+	 *  %grandchild_one% => $this->posts['grandchild_one']
 	 *
 	 * Those keys are determined by the json file used to load initial post data:
-	 * 	tests/fixture/test_posts.json
+	 *  tests/fixture/test_posts.json
 	 */
 	protected function load_manager_post( $file ) {
 
-		if ( ! is_readable( $file ) )
+		if ( ! is_readable( $file ) ) {
 			return false;
+		}
 
 		$data = file_get_contents( $file );
 		$save = (array) json_decode( stripslashes( $data ) );
 
 		$output = array(
-			'navman-moves' => array(),
-			'navman-inserts' => array(),
-			'navman-updates' => array(),
-			'navman-deletions' => array()
-			);
+			'navman-moves'     => array(),
+			'navman-inserts'   => array(),
+			'navman-updates'   => array(),
+			'navman-deletions' => array(),
+		);
 
-		$moves = (array) $save['navman-moves'];
-		$inserts = (array) $save['navman-inserts'];
-		$updates = (array) $save['navman-updates'];
+		$moves     = (array) $save['navman-moves'];
+		$inserts   = (array) $save['navman-inserts'];
+		$updates   = (array) $save['navman-updates'];
 		$deletions = $save['navman-deletions'];
 
-		foreach( $moves as $id => $move ) {
+		foreach ( $moves as $id => $move ) {
 			// Convert ID fields
-			$id = $this->_convert_post_id( $id );
-			$move->ID = $this->_convert_post_id( $move->ID );
-			$move->post_parent = $this->_convert_post_id( $move->post_parent );
-			$output['navman-moves'][$id] = $move;
+			$id                            = $this->_convert_post_id( $id );
+			$move->ID                      = $this->_convert_post_id( $move->ID );
+			$move->post_parent             = $this->_convert_post_id( $move->post_parent );
+			$output['navman-moves'][ $id ] = $move;
 		}
-		foreach( $inserts as $id => $insert ) {
+		foreach ( $inserts as $id => $insert ) {
 			// Convert ID fields
-			$id = $this->_convert_post_id( $id );
-			$insert->post_parent = $this->_convert_post_id( $insert->post_parent );
-			$output['navman-inserts'][$id] = $insert;
+			$id                              = $this->_convert_post_id( $id );
+			$insert->post_parent             = $this->_convert_post_id( $insert->post_parent );
+			$output['navman-inserts'][ $id ] = $insert;
 		}
-		foreach( $updates as $id => $update ) {
+		foreach ( $updates as $id => $update ) {
 			// Convert ID fields
-			$id = $this->_convert_post_id( $id );
-			$update->ID = $this->_convert_post_id( $update->ID );
-			$update->post_parent = $this->_convert_post_id( $update->post_parent );
-			$output['navman-updates'][$id] = $update;
+			$id                              = $this->_convert_post_id( $id );
+			$update->ID                      = $this->_convert_post_id( $update->ID );
+			$update->post_parent             = $this->_convert_post_id( $update->post_parent );
+			$output['navman-updates'][ $id ] = $update;
 		}
-		foreach( $deletions as $id ) {
+		foreach ( $deletions as $id ) {
 			// Convert ID fields
 			$id = $this->_convert_post_id( $id );
 			array_push( $output['navman-deletions'], $id );
@@ -450,7 +460,7 @@ class Test_BU_Navigation_Admin_Manager extends BU_Navigation_UnitTestCase {
 
 	protected function _replace_id( $matches ) {
 		if ( ! empty( $matches[1] ) && array_key_exists( $matches[1], $this->posts ) ) {
-			return $this->posts[$matches[1]];
+			return $this->posts[ $matches[1] ];
 		}
 		return $matches[0];
 	}

--- a/tests/phpunit/test-extras.php
+++ b/tests/phpunit/test-extras.php
@@ -14,10 +14,25 @@ class Test_BU_Navigation_Extras extends BU_Navigation_UnitTestCase {
 	 */
 	public function test_navigation_exclude() {
 
-		$parent = $this->factory->post->create( array( 'post_type' => 'page' ) );
-		$child = $this->factory->post->create( array( 'post_type' => 'page', 'post_parent' => $parent ) );
-		$hidden_child = $this->factory->post->create( array( 'post_type' => 'page','post_parent' => $parent ) );
-		$hidden_link = $this->factory->post->create( array( 'post_type' => 'bu_link','post_parent' => $parent ) );
+		$parent       = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$child        = $this->factory->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_parent' => $parent,
+			)
+		);
+		$hidden_child = $this->factory->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_parent' => $parent,
+			)
+		);
+		$hidden_link  = $this->factory->post->create(
+			array(
+				'post_type'   => 'bu_link',
+				'post_parent' => $parent,
+			)
+		);
 
 		// 1. Test default value (do not exclude)
 		$posts = bu_navigation_get_posts();

--- a/tests/phpunit/test-library.php
+++ b/tests/phpunit/test-library.php
@@ -17,10 +17,13 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		parent::setUp();
 
 		global $wp_rewrite;
-		$wp_rewrite->set_permalink_structure('/%year%/%monthnum%/%day%/%postname%/');
+		$wp_rewrite->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%/' );
 
 		// Set up custom post type - 'test'
-		$args = array( 'hierarchical' => true, 'public' => true );
+		$args = array(
+			'hierarchical' => true,
+			'public'       => true,
+		);
 		register_post_type( 'test', $args );
 
 		// Setup posts
@@ -29,31 +32,34 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 	}
 
 	/**
-	 *	Covers bu_navigation_supported_post_types()
+	 *  Covers bu_navigation_supported_post_types()
 	 */
 	public function test_bu_navigation_supported_post_types() {
 
 		// Post Types without Link pages + test
-		$exp_post_types = array( "page" => "page", "test" => "test" );
-		$post_types = bu_navigation_supported_post_types();
+		$exp_post_types = array(
+			'page' => 'page',
+			'test' => 'test',
+		);
+		$post_types     = bu_navigation_supported_post_types();
 		$this->assertEquals( $exp_post_types, $post_types );
 
 		// Add "Link" to expected post types
-		$exp_post_types["bu_link"] = "bu_link";
-		$post_types = bu_navigation_supported_post_types( true );
+		$exp_post_types['bu_link'] = 'bu_link';
+		$post_types                = bu_navigation_supported_post_types( true );
 		$this->assertEquals( $exp_post_types, $post_types );
 
 	}
 
 	/**
-	 *	Covers bu_navigation_load_sections()
+	 *  Covers bu_navigation_load_sections()
 	 */
 	public function test_bu_navigation_load_sections() {
 
 		// Load all values and split into section and pages
 		$returned = bu_navigation_load_sections();
 		$sections = $returned['sections'];
-		$pages 	  = $returned['pages'];
+		$pages    = $returned['pages'];
 
 		/*
 		*	Test Sections
@@ -61,32 +67,32 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 
 		// These are the expected section result arrays
 		$section_parent = array(
-				(string)$this->posts['parent'],
-				(string)$this->posts['parent_two'],
-				(string)$this->posts['hidden'],
-				(string)$this->posts['edit'],
-				(string)$this->posts['google'],
-				(string)$this->posts['last_page']
-			);
+			(string) $this->posts['parent'],
+			(string) $this->posts['parent_two'],
+			(string) $this->posts['hidden'],
+			(string) $this->posts['edit'],
+			(string) $this->posts['google'],
+			(string) $this->posts['last_page'],
+		);
 
 		$section_child = array(
-				(string)$this->posts['child']
+			(string) $this->posts['child'],
 		);
 
 		$section_grandchildren = array(
-				(string)$this->posts['grandchild_one'],
-				(string)$this->posts['grandchild_two']
+			(string) $this->posts['grandchild_one'],
+			(string) $this->posts['grandchild_two'],
 		);
 
 		$section_greatgrandchildren = array(
-				(string)$this->posts['greatgrandchild']
-				);
+			(string) $this->posts['greatgrandchild'],
+		);
 
 		// Sort through the sections and compare them to the
 		// expected results. If each section doesn't match one
 		// of the expected, $good_section = false
 		$good_sections = false;
-		foreach( $sections as $section ) {
+		foreach ( $sections as $section ) {
 
 			$diff1 = array_diff( $section, $section_parent );
 			$diff2 = array_diff( $section, $section_child );
@@ -98,7 +104,6 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 			} else {
 				$good_sections = false;
 			}
-
 		}
 
 		// See if all of the sections match
@@ -109,31 +114,43 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		*/
 
 		$good_pages = false;
-		foreach( $pages as $key => $value ) {
+		foreach ( $pages as $key => $value ) {
 
 			// If the Child Page, value should be parent
-			if( $key == $this->posts['child'] ) {
-				if ( $value != $this->posts['parent'] ) $good_pages = true;
-				else $good_pages = false;
+			if ( $key == $this->posts['child'] ) {
+				if ( $value != $this->posts['parent'] ) {
+					$good_pages = true;
+				} else {
+					$good_pages = false;
+				}
 			}
 
 			// If Grandchild page, value should be child
-			elseif( $key == $this->posts['grandchild_one'] or
-					$key == $this->posts['grandchild_two']) {
-				if( $value == $this->posts['child'] ) $good_pages = true;
-				else $good_pages = false;
+			elseif ( $key == $this->posts['grandchild_one'] or
+					$key == $this->posts['grandchild_two'] ) {
+				if ( $value == $this->posts['child'] ) {
+					$good_pages = true;
+				} else {
+					$good_pages = false;
+				}
 			}
 
 			// If Greatgrandchild page, value should be grandchild_one
-			elseif( $key == $this->posts['greatgrandchild'] ) {
-				if( $value == $this->posts['grandchild_one'] ) $good_pages = true;
-				else $good_pages = false;
+			elseif ( $key == $this->posts['greatgrandchild'] ) {
+				if ( $value == $this->posts['grandchild_one'] ) {
+					$good_pages = true;
+				} else {
+					$good_pages = false;
+				}
 			}
 
 			// Else value should equal 0
 			else {
-				if( $value == 0 ) $good_pages = true;
-				else $good_pages = false;
+				if ( $value == 0 ) {
+					$good_pages = true;
+				} else {
+					$good_pages = false;
+				}
 			}
 		}
 
@@ -147,36 +164,37 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		// Test that when the 'test' post type is included, it appears
 		// in the pages section but not when it isn't included.
 		$returned_w_post_type = bu_navigation_load_sections( array( 'test' ) );
-		$pages_w_post_type = $returned_w_post_type['pages'];
+		$pages_w_post_type    = $returned_w_post_type['pages'];
 
 		$good_posttype = false;
 
 		// If the 'test' page isn't in orignial pages but is in new pages
-		if ( !isset( $pages[$this->posts['test']]) and
-			  isset( $pages_w_post_type[$this->posts['test']]) ) {
-				  $good_posttype = true;
-			  }
+		if ( ! isset( $pages[ $this->posts['test'] ] ) and
+			isset( $pages_w_post_type[ $this->posts['test'] ] ) ) {
+				$good_posttype = true;
+		}
 
 		$this->assertTrue( $good_posttype );
 	}
 
 	/**
-	 *	Covers bu_navigation_gather_childsections()
+	 *  Covers bu_navigation_gather_childsections()
 	 */
 	public function test_bu_navigation_gather_childsections() {
 
-		$all_sections = bu_navigation_load_sections();
-		$parent = $this->posts['parent'];
-		$child = $this->posts['child'];
-		$grandchild_one = $this->posts['grandchild_one'];
+		$all_sections       = bu_navigation_load_sections();
+		$parent             = $this->posts['parent'];
+		$child              = $this->posts['child'];
+		$grandchild_one     = $this->posts['grandchild_one'];
 		$good_childsections = false;
 
 		// $parent should return child and grandchild_one as the only sections
 		$child_sections = Navigation\gather_childsections( $parent, $all_sections['sections'] );
-		if( count( $child_sections ) == 2 and
-			$child_sections[0] == $child  and
-			$child_sections[1] == $grandchild_one )
+		if ( count( $child_sections ) == 2 and
+			$child_sections[0] == $child and
+			$child_sections[1] == $grandchild_one ) {
 			$good_childsections = true;
+		}
 
 		$this->assertTrue( $good_childsections );
 
@@ -199,13 +217,13 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 	 */
 	public function test_bu_navigation_get_page_depth() {
 
-		$parent = $this->posts['parent'];
-		$child = $this->posts['child'];
-		$grandchild_one = $this->posts['grandchild_one'];
+		$parent          = $this->posts['parent'];
+		$child           = $this->posts['child'];
+		$grandchild_one  = $this->posts['grandchild_one'];
 		$greatgrandchild = $this->posts['greatgrandchild'];
 
 		// Get depth results
-		$grandchild_depth_results = bu_navigation_get_page_depth( $grandchild_one );
+		$grandchild_depth_results      = bu_navigation_get_page_depth( $grandchild_one );
 		$greatgrandchild_depth_results = bu_navigation_get_page_depth( $greatgrandchild );
 
 		// Test depth functionality
@@ -214,8 +232,8 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 
 		/* Selective Section Functionality */
 
-		$test_grandchild = $this->posts['test_grandchild'];
-		$selective_section = bu_navigation_load_sections('test');
+		$test_grandchild         = $this->posts['test_grandchild'];
+		$selective_section       = bu_navigation_load_sections( 'test' );
 		$selective_depth_results = bu_navigation_get_page_depth( $test_grandchild, $selective_section );
 
 		// Test selective section functionality
@@ -228,30 +246,30 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 	 */
 	public function test_bu_navigation_gather_sections() {
 
-		$parent = $this->posts['parent'];
-		$child = $this->posts['child'];
-		$grandchild_one = $this->posts['grandchild_one'];
+		$parent          = $this->posts['parent'];
+		$child           = $this->posts['child'];
+		$grandchild_one  = $this->posts['grandchild_one'];
 		$greatgrandchild = $this->posts['greatgrandchild'];
 
 		/* Base Functionality */
 
 		$grandchild_expected = array(
-			strval(0),
-			strval($parent),
-			strval($child),
-			$grandchild_one
+			strval( 0 ),
+			strval( $parent ),
+			strval( $child ),
+			$grandchild_one,
 		);
 
 		$child_expected = array(
-			strval(0),
-			strval($parent),
-			$child
+			strval( 0 ),
+			strval( $parent ),
+			$child,
 		);
 
 		// Gather test results
-		$grandchild_results = bu_navigation_gather_sections( $grandchild_one, NULL, NULL );
-		$greatgrandchild_results = bu_navigation_gather_sections( $greatgrandchild, NULL, NULL );
-		$child_results = bu_navigation_gather_sections( $child, NULL, NULL );
+		$grandchild_results      = bu_navigation_gather_sections( $grandchild_one, null, null );
+		$greatgrandchild_results = bu_navigation_gather_sections( $greatgrandchild, null, null );
+		$child_results           = bu_navigation_gather_sections( $child, null, null );
 
 		// Test base functionality
 		$this->assertEquals( $child_results, $child_expected );
@@ -263,12 +281,12 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		$child_down_expected = array( strval( $grandchild_one ), strval( $child ) );
 
 		$parent_down_expected = $child_down_expected;
-		array_push( $parent_down_expected, strval( $parent ));
+		array_push( $parent_down_expected, strval( $parent ) );
 
 		// Get Down results
-		$args = array( 'direction' => 'down' );
-		$child_down_results = bu_navigation_gather_sections( $child, $args, NULL );
-		$parent_down_results = bu_navigation_gather_sections( $parent, $args, NULL );
+		$args                = array( 'direction' => 'down' );
+		$child_down_results  = bu_navigation_gather_sections( $child, $args, null );
+		$parent_down_results = bu_navigation_gather_sections( $parent, $args, null );
 
 		// Test down functionality
 		$this->assertEquals( $child_down_results, $child_down_expected );
@@ -280,8 +298,11 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		$parent_depth_expected = array( strval( $child ), strval( $parent ) );
 
 		// Get depth results
-		$args = array( 'depth' => '1', 'direction' => 'down' );
-		$parent_depth_results = bu_navigation_gather_sections( $parent, $args, NULL );
+		$args                 = array(
+			'depth'     => '1',
+			'direction' => 'down',
+		);
+		$parent_depth_results = bu_navigation_gather_sections( $parent, $args, null );
 
 		// Test depth functionality
 		$this->assertEquals( $parent_depth_results, $parent_depth_expected );
@@ -289,15 +310,15 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		/* Custom Post Type Functionality */
 
 		// Expected custom post type results
-		$test = $this->posts['test'];
-		$test_child = $this->posts['test_child'];
+		$test            = $this->posts['test'];
+		$test_child      = $this->posts['test_child'];
 		$test_grandchild = $this->posts['test_grandchild'];
 
-		$grandchild_posttype_expected = array( strval(0), strval($test), strval( $test_child ));
+		$grandchild_posttype_expected = array( strval( 0 ), strval( $test ), strval( $test_child ) );
 
 		// Get custom post type results
-		$args = array( 'post_types' => array( 'test' ) );
-		$grandchild_posttype_results = bu_navigation_gather_sections( $test_grandchild, $args, NULL );
+		$args                        = array( 'post_types' => array( 'test' ) );
+		$grandchild_posttype_results = bu_navigation_gather_sections( $test_grandchild, $args, null );
 
 		// Test custom post type functionality
 		$this->assertEquals( $grandchild_posttype_results, $grandchild_posttype_expected );
@@ -307,8 +328,8 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		// Section results
 		// By giving the function only the pages from test and the seleced posts it should
 		// yeild the same results if we had give it the post_type parameter (previous assertion)
-		$selective_section = bu_navigation_load_sections('test');
-		$selective_section_results = bu_navigation_gather_sections( $test_grandchild, NULL, $selective_section );
+		$selective_section         = bu_navigation_load_sections( 'test' );
+		$selective_section_results = bu_navigation_gather_sections( $test_grandchild, null, $selective_section );
 
 		// Test selective section functionality
 		$this->assertEquals( $selective_section_results, $grandchild_posttype_expected );
@@ -321,29 +342,29 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 	public function test_bu_navigation_get_urls() {
 
 		// Get test page ids
-		$parent 		 = $this->posts['parent'];
-		$grandchild_one  = $this->posts['grandchild_one'];
-		$test_child 	 = $this->posts['test_child'];
+		$parent         = $this->posts['parent'];
+		$grandchild_one = $this->posts['grandchild_one'];
+		$test_child     = $this->posts['test_child'];
 
 		// Get all pages
-		$args  = array( 'post_types' => array( 'page', 'bu_link', 'test' ));
+		$args  = array( 'post_types' => array( 'page', 'bu_link', 'test' ) );
 		$pages = bu_navigation_get_pages( $args );
 
 		// Get the base url
 		$base_url = trailingslashit( get_option( 'home' ) );
 
 		// Remove current url
-		unset( $pages[$parent]->url );
-		unset( $pages[$grandchild_one]->url );
-		unset( $pages[$test_child]->url );
+		unset( $pages[ $parent ]->url );
+		unset( $pages[ $grandchild_one ]->url );
+		unset( $pages[ $test_child ]->url );
 
 		// Use get_urls to get the new url
 		$pages = Navigation\get_urls( $pages );
 
 		// Test to make sure the url is the expected one
-		$this->assertEquals( get_permalink($parent), $pages[$parent]->url );
-		$this->assertEquals( get_permalink($grandchild_one), $pages[$grandchild_one]->url );
-		$this->assertEquals( get_permalink($test_child), $pages[$test_child]->url );
+		$this->assertEquals( get_permalink( $parent ), $pages[ $parent ]->url );
+		$this->assertEquals( get_permalink( $grandchild_one ), $pages[ $grandchild_one ]->url );
+		$this->assertEquals( get_permalink( $test_child ), $pages[ $test_child ]->url );
 
 	}
 
@@ -354,10 +375,13 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 	public function test_bu_navigation_get_urls_without_ancestors() {
 
 		// Fetch all posts in "parent" section
-		$parent = $this->posts['parent'];
+		$parent   = $this->posts['parent'];
 		$sections = bu_navigation_gather_sections( $parent, array( 'direction' => 'down' ) );
-		$args = array( 'sections' => $sections, 'post_types' => array( 'page', 'bu_link', 'test' ));
-		$pages  = bu_navigation_get_pages( $args );
+		$args     = array(
+			'sections'   => $sections,
+			'post_types' => array( 'page', 'bu_link', 'test' ),
+		);
+		$pages    = bu_navigation_get_pages( $args );
 
 		foreach ( $pages as $page ) {
 			$this->assertEquals( get_permalink( $page->ID ), $page->url );
@@ -382,20 +406,59 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 	}
 
 	public function test_bu_navigation_get_page_link_unpublished() {
-		$public = $this->factory->post->create(array('post_type' => 'page', 'post_status' => 'publish'));
-		$draft_child = $this->factory->post->create(array('post_type' => 'page', 'post_status' => 'draft', 'post_parent' => $public));
-		$pending_child = $this->factory->post->create(array('post_type' => 'page', 'post_status' => 'pending', 'post_parent' => $public));
-		$draft = $this->factory->post->create(array('post_type' => 'page', 'post_status' => 'draft'));
-		$public_draft_child = $this->factory->post->create(array('post_type' => 'page', 'post_status' => 'publish', 'post_parent' => $draft));
-		$pending = $this->factory->post->create(array('post_type' => 'page', 'post_status' => 'pending'));
-		$public_pending_child = $this->factory->post->create(array('post_type' => 'page', 'post_status' => 'publish', 'post_parent' => $pending));
+		$public               = $this->factory->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+			)
+		);
+		$draft_child          = $this->factory->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'draft',
+				'post_parent' => $public,
+			)
+		);
+		$pending_child        = $this->factory->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'pending',
+				'post_parent' => $public,
+			)
+		);
+		$draft                = $this->factory->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'draft',
+			)
+		);
+		$public_draft_child   = $this->factory->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_parent' => $draft,
+			)
+		);
+		$pending              = $this->factory->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'pending',
+			)
+		);
+		$public_pending_child = $this->factory->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_parent' => $pending,
+			)
+		);
 
 		// Our functions require post objects
-		$draft = get_post( $draft );
-		$draft_child = get_post( $draft_child );
-		$pending = get_post( $draft_child );
-		$pending_child = get_post( $pending_child );
-		$public_draft_child = get_post( $public_draft_child );
+		$draft                = get_post( $draft );
+		$draft_child          = get_post( $draft_child );
+		$pending              = get_post( $draft_child );
+		$pending_child        = get_post( $pending_child );
+		$public_draft_child   = get_post( $public_draft_child );
 		$public_pending_child = get_post( $public_pending_child );
 
 		// Root unpublished
@@ -448,16 +511,43 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 	public function test_bu_navigation_get_post_link_unpublished() {
 		global $wp_rewrite;
 
-		$public = $this->factory->post->create(array('post_type' => 'test', 'post_status' => 'publish'));
-		$draft_child = $this->factory->post->create(array('post_type' => 'test', 'post_status' => 'draft', 'post_parent' => $public));
-		$pending_child = $this->factory->post->create(array('post_type' => 'test', 'post_status' => 'pending', 'post_parent' => $public));
-		$draft = $this->factory->post->create(array('post_type' => 'test', 'post_status' => 'draft'));
-		$pending = $this->factory->post->create(array('post_type' => 'test', 'post_status' => 'pending'));
+		$public        = $this->factory->post->create(
+			array(
+				'post_type'   => 'test',
+				'post_status' => 'publish',
+			)
+		);
+		$draft_child   = $this->factory->post->create(
+			array(
+				'post_type'   => 'test',
+				'post_status' => 'draft',
+				'post_parent' => $public,
+			)
+		);
+		$pending_child = $this->factory->post->create(
+			array(
+				'post_type'   => 'test',
+				'post_status' => 'pending',
+				'post_parent' => $public,
+			)
+		);
+		$draft         = $this->factory->post->create(
+			array(
+				'post_type'   => 'test',
+				'post_status' => 'draft',
+			)
+		);
+		$pending       = $this->factory->post->create(
+			array(
+				'post_type'   => 'test',
+				'post_status' => 'pending',
+			)
+		);
 
 		// Our functions require post objects
-		$draft = get_post( $draft );
-		$draft_child = get_post( $draft_child );
-		$pending = get_post( $draft_child );
+		$draft         = get_post( $draft );
+		$draft_child   = get_post( $draft_child );
+		$pending       = get_post( $draft_child );
 		$pending_child = get_post( $pending_child );
 
 		// Root unpublished
@@ -487,23 +577,45 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 	 * @return null
 	 */
 	public function test_bu_navigation_get_post_link_unpublished_public_children() {
-		$draft = $this->factory->post->create(array('post_type' => 'test', 'post_status' => 'draft'));
-		$public_draft_child = $this->factory->post->create(array('post_type' => 'test', 'post_status' => 'publish', 'post_parent' => $draft));
-		$pending = $this->factory->post->create(array('post_type' => 'test', 'post_status' => 'pending'));
-		$public_pending_child = $this->factory->post->create(array('post_type' => 'test', 'post_status' => 'publish', 'post_parent' => $pending));
+		$draft                = $this->factory->post->create(
+			array(
+				'post_type'   => 'test',
+				'post_status' => 'draft',
+			)
+		);
+		$public_draft_child   = $this->factory->post->create(
+			array(
+				'post_type'   => 'test',
+				'post_status' => 'publish',
+				'post_parent' => $draft,
+			)
+		);
+		$pending              = $this->factory->post->create(
+			array(
+				'post_type'   => 'test',
+				'post_status' => 'pending',
+			)
+		);
+		$public_pending_child = $this->factory->post->create(
+			array(
+				'post_type'   => 'test',
+				'post_status' => 'publish',
+				'post_parent' => $pending,
+			)
+		);
 
 		// "publish and unpublish" to generate post_name
-		$public_draft_child = get_post( $public_draft_child );
+		$public_draft_child              = get_post( $public_draft_child );
 		$public_draft_child->post_status = 'publish';
-		wp_update_post($public_draft_child);
+		wp_update_post( $public_draft_child );
 		$public_draft_child->post_status = 'draft';
-		wp_update_post($public_draft_child);
+		wp_update_post( $public_draft_child );
 
-		$public_pending_child = get_post( $public_pending_child );
+		$public_pending_child              = get_post( $public_pending_child );
 		$public_pending_child->post_status = 'publish';
-		wp_update_post($public_pending_child);
+		wp_update_post( $public_pending_child );
 		$public_pending_child->post_status = 'pending';
-		wp_update_post($public_pending_child);
+		wp_update_post( $public_pending_child );
 
 		// Draft parent, public children
 		$this->assertEquals( get_post_permalink( $public_draft_child ), Navigation\get_nav_post_link( $public_draft_child ) );
@@ -525,16 +637,49 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		$wp_rewrite->set_permalink_structure( '' );
 		delete_option( 'rewrite_rules' );
 
-		register_post_type( 'cpt_one', array( 'public' => true, 'hierarchical' => true, 'query_var' => false ) );
-		register_post_type( 'cpt_two', array( 'public' => true, 'hierarchical' => true, 'query_var' => true ) );
-		register_post_type( 'cpt_three', array( 'public' => true, 'hierarchical' => true, 'query_var' => 'foo' ) );
+		register_post_type(
+			'cpt_one', array(
+				'public'       => true,
+				'hierarchical' => true,
+				'query_var'    => false,
+			)
+		);
+		register_post_type(
+			'cpt_two', array(
+				'public'       => true,
+				'hierarchical' => true,
+				'query_var'    => true,
+			)
+		);
+		register_post_type(
+			'cpt_three', array(
+				'public'       => true,
+				'hierarchical' => true,
+				'query_var'    => 'foo',
+			)
+		);
 
-		$cpt_one = $this->factory->post->create(array('post_type' => 'cpt_one', 'post_status' => 'publish'));
-		$cpt_two = $this->factory->post->create(array('post_type' => 'cpt_two', 'post_status' => 'publish'));
-		$cpt_three = $this->factory->post->create(array('post_type' => 'cpt_three', 'post_status' => 'publish'));
+		$cpt_one   = $this->factory->post->create(
+			array(
+				'post_type'   => 'cpt_one',
+				'post_status' => 'publish',
+			)
+		);
+		$cpt_two   = $this->factory->post->create(
+			array(
+				'post_type'   => 'cpt_two',
+				'post_status' => 'publish',
+			)
+		);
+		$cpt_three = $this->factory->post->create(
+			array(
+				'post_type'   => 'cpt_three',
+				'post_status' => 'publish',
+			)
+		);
 
-		$cpt_one = get_post( $cpt_one );
-		$cpt_two = get_post( $cpt_two );
+		$cpt_one   = get_post( $cpt_one );
+		$cpt_two   = get_post( $cpt_two );
 		$cpt_three = get_post( $cpt_three );
 
 		$this->assertEquals( get_post_permalink( $cpt_one ), Navigation\get_nav_post_link( $cpt_one ) );
@@ -552,8 +697,8 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		*/
 
 		// Don't include custom post type in args and check it isn't returned
-		$pages = bu_navigation_get_pages();
-		$custom_post_type = 'test';
+		$pages                   = bu_navigation_get_pages();
+		$custom_post_type        = 'test';
 		$custom_post_type_exists = false;
 		foreach ( $pages as $page ) {
 			if ( $page->post_type == $custom_post_type ) {
@@ -561,13 +706,13 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 			}
 		}
 
-		$this->assertArrayNotHasKey( $this->posts['test_child'], $pages );	// look for custom post types posts explicitly
-		$this->assertFalse( $custom_post_type_exists );	// assertFalse vs. assertEquals( $arg, false )
+		$this->assertArrayNotHasKey( $this->posts['test_child'], $pages );  // look for custom post types posts explicitly
+		$this->assertFalse( $custom_post_type_exists ); // assertFalse vs. assertEquals( $arg, false )
 
 		// Add the custom post type to args and make sure it is returned
-		$args = array( 'post_types' => array( 'page', 'bu_link', 'test' ));
-		$pages = bu_navigation_get_pages( $args );
-		$custom_post_type = 'test';
+		$args                    = array( 'post_types' => array( 'page', 'bu_link', 'test' ) );
+		$pages                   = bu_navigation_get_pages( $args );
+		$custom_post_type        = 'test';
 		$custom_post_type_exists = false;
 		foreach ( $pages as $page ) {
 			if ( $page->post_type == $custom_post_type ) {
@@ -575,7 +720,7 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 			}
 		}
 
-		$this->assertArrayHasKey( $this->posts['test_child'], $pages );	// look for custom post types posts explicitly
+		$this->assertArrayHasKey( $this->posts['test_child'], $pages ); // look for custom post types posts explicitly
 		$this->assertTrue( $custom_post_type_exists );
 
 		/*
@@ -583,45 +728,46 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		*/
 
 		unset( $args );
-		$args = array( 'max_items' => 2 );
+		$args  = array( 'max_items' => 2 );
 		$pages = bu_navigation_get_pages( $args );
-		$this->assertEquals( 2, count( $pages ));
+		$this->assertEquals( 2, count( $pages ) );
 
 		/*
 		*	Test for Page status - Draft + Pending
 		*/
 
 		unset( $args );
-		$args = array( 'post_status' => 'draft' );
-		$pages = bu_navigation_get_pages( $args );
+		$args       = array( 'post_status' => 'draft' );
+		$pages      = bu_navigation_get_pages( $args );
 		$draft_page = $this->posts['draft'];
-		$this->assertTrue( array_key_exists( $draft_page, $pages ));
+		$this->assertTrue( array_key_exists( $draft_page, $pages ) );
 
 		unset( $args );
-		$args = array( 'post_status' => 'pending' );
-		$pages = bu_navigation_get_pages( $args );
+		$args         = array( 'post_status' => 'pending' );
+		$pages        = bu_navigation_get_pages( $args );
 		$pending_page = $this->posts['pending'];
-		$this->assertTrue( array_key_exists( $pending_page, $pages ));
+		$this->assertTrue( array_key_exists( $pending_page, $pages ) );
 
 		// @todo multiple statuses
-
 		/*
 		*	Test Gathering Specific Sections
 		*/
 
 		$parent = $this->posts['parent'];
-		$child = $this->posts['child'];
+		$child  = $this->posts['child'];
 
 		// Get results of $parent section
 		unset( $args );
-		$args = array( 'sections' => array( $parent ));
+		$args  = array( 'sections' => array( $parent ) );
 		$pages = bu_navigation_get_pages( $args );
 
-		$expected_parent_section_results = array( (string)$child );
+		$expected_parent_section_results = array( (string) $child );
 
 		// Gather results
 		$pages_id = array();
-		foreach( $pages as $page ) array_push( $pages_id, $page->ID );
+		foreach ( $pages as $page ) {
+			array_push( $pages_id, $page->ID );
+		}
 
 		// Test only the $parent section pages were returned
 		$this->assertEquals( $pages_id, $expected_parent_section_results );
@@ -632,16 +778,18 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 
 		// Get results
 		unset( $args );
-		$args = array( 'sections' => array( $child ));
+		$args  = array( 'sections' => array( $child ) );
 		$pages = bu_navigation_get_pages( $args );
 
 		$expected_child_section_results = array(
-			(string)$grandchild_one,
-			(string)$grandchild_two
-			);
+			(string) $grandchild_one,
+			(string) $grandchild_two,
+		);
 
 		$pages_id = array();
-		foreach( $pages as $page ) array_push( $pages_id, $page->ID );
+		foreach ( $pages as $page ) {
+			array_push( $pages_id, $page->ID );
+		}
 
 		// Test only the $child section pages were returned
 		$this->assertEquals( $pages_id, $expected_child_section_results );
@@ -651,14 +799,15 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		*/
 
 		unset( $args );
-		$args = array( 'pages' => array( $parent, $child ));
+		$args  = array( 'pages' => array( $parent, $child ) );
 		$pages = bu_navigation_get_pages( $args );
 
 		$gather_test = false;
-		if( count( $pages ) == 2 and
+		if ( count( $pages ) == 2 and
 			array_key_exists( $parent, $pages ) and
-			array_key_exists( $child, $pages ))
+			array_key_exists( $child, $pages ) ) {
 			$gather_test = true;
+		}
 
 		$this->assertTrue( $gather_test );
 
@@ -671,25 +820,36 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		register_post_type( 'order', $cpt_args );
 
 		// Create pages using the 'order' post type
-		$page_args = array( 'post_type' => 'order' , 'menu_order' => '2' );
+		$page_args  = array(
+			'post_type'  => 'order',
+			'menu_order' => '2',
+		);
 		$last_order = $this->factory->post->create( $page_args );
 
-		$page_args = array( 'post_type' => 'order' , 'menu_order' => '1' );
+		$page_args    = array(
+			'post_type'  => 'order',
+			'menu_order' => '1',
+		);
 		$middle_order = $this->factory->post->create( $page_args );
 
-		$page_args = array( 'post_type' => 'order' , 'menu_order' => '0' );
+		$page_args   = array(
+			'post_type'  => 'order',
+			'menu_order' => '0',
+		);
 		$first_order = $this->factory->post->create( $page_args );
 
 		// Construct Expected Order
 		$expected_order = array( $first_order, $middle_order, $last_order );
 
 		// Get Pages
-		$args = array( 'post_types' => array( 'order' ));
+		$args  = array( 'post_types' => array( 'order' ) );
 		$pages = bu_navigation_get_pages( $args );
 
 		// Get actual page order
 		$actual_order = array();
-		foreach( $pages as $page ) array_push( $actual_order, $page->ID );
+		foreach ( $pages as $page ) {
+			array_push( $actual_order, $page->ID );
+		}
 
 		// Test order
 		$this->assertEquals( $actual_order, $expected_order );
@@ -698,20 +858,28 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		*	Test Supress URLS
 		*/
 
-		$pages = bu_navigation_get_pages();
+		$pages   = bu_navigation_get_pages();
 		$has_url = false;
-		foreach ( $pages as $page ) if( isset( $page->url )) $has_url = true;
+		foreach ( $pages as $page ) {
+			if ( isset( $page->url ) ) {
+				$has_url = true;
+			}
+		}
 
 		// Test to make sure the pages do have urls
 		$this->assertTrue( $has_url );
 
 		// Suppress URLs
 		unset( $args );
-		$args = array( 'suppress_urls' => true );
+		$args  = array( 'suppress_urls' => true );
 		$pages = bu_navigation_get_pages( $args );
 
 		$has_url = false;
-		foreach ( $pages as $page ) if( isset( $page->URL )) $has_url = true;
+		foreach ( $pages as $page ) {
+			if ( isset( $page->URL ) ) {
+				$has_url = true;
+			}
+		}
 
 		// Test to make sure the pages don't have urls
 		$this->assertFalse( $has_url );
@@ -726,17 +894,25 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		$pages = bu_navigation_get_pages();
 
 		$test_filter_present = false;
-		foreach( $pages as $page ) if( isset( $page->post_filter_example ) ) $test_filter_present = true;
+		foreach ( $pages as $page ) {
+			if ( isset( $page->post_filter_example ) ) {
+				$test_filter_present = true;
+			}
+		}
 
 		// The test filter should be present
 		$this->assertTrue( $test_filter_present );
 
 		unset( $args );
-		$args = array( 'suppress_filter_pages' => true );
+		$args  = array( 'suppress_filter_pages' => true );
 		$pages = bu_navigation_get_pages( $args );
 
 		$test_filter_present = false;
-		foreach( $pages as $page ) if( isset( $page->post_filter_example )) $test_filter_present = true;
+		foreach ( $pages as $page ) {
+			if ( isset( $page->post_filter_example ) ) {
+				$test_filter_present = true;
+			}
+		}
 
 		// The test filter should not be present
 		$this->assertFalse( $test_filter_present );
@@ -745,28 +921,29 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 
 	/**
 	 * Covers bu_navigation_pages_by_parent()
+	 *
 	 * @todo finish
 	 */
 	public function test_bu_navigation_pages_by_parent() {
 
-		$parent 		 = $this->posts['parent'];
-		$child 			 = $this->posts['child'];
-		$parent_two 	 = $this->posts['parent_two'];
-		$edit 			 = $this->posts['edit'];
-		$google 		 = $this->posts['google'];
-		$last_page		 = $this->posts['last_page'];
+		$parent          = $this->posts['parent'];
+		$child           = $this->posts['child'];
+		$parent_two      = $this->posts['parent_two'];
+		$edit            = $this->posts['edit'];
+		$google          = $this->posts['google'];
+		$last_page       = $this->posts['last_page'];
 		$grandchild_one  = $this->posts['grandchild_one'];
 		$grandchild_two  = $this->posts['grandchild_two'];
 		$greatgrandchild = $this->posts['greatgrandchild'];
 
 		$all_pages = bu_navigation_get_pages();
 
-		$parent_value 		= array( $all_pages[ $child ] );
-		$child_value 		= array(
-								$all_pages[ $grandchild_one ],
-								$all_pages[ $grandchild_two ],
-								);
-		$grandchild_value 	= array( $all_pages[ $greatgrandchild ]);
+		$parent_value     = array( $all_pages[ $child ] );
+		$child_value      = array(
+			$all_pages[ $grandchild_one ],
+			$all_pages[ $grandchild_two ],
+		);
+		$grandchild_value = array( $all_pages[ $greatgrandchild ] );
 
 		$pages_results = bu_navigation_pages_by_parent( $all_pages );
 
@@ -794,47 +971,47 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 	 */
 	public function test_bu_navigation_pages_by_parent_menu_sort() {
 
-		$parent 		 = $this->posts['parent'];
-		$child 			 = $this->posts['child'];
-		$parent_two 	 = $this->posts['parent_two'];
-		$edit 			 = $this->posts['edit'];
-		$hidden 		 = $this->posts['hidden'];
-		$google 		 = $this->posts['google'];
-		$last_page		 = $this->posts['last_page'];
+		$parent          = $this->posts['parent'];
+		$child           = $this->posts['child'];
+		$parent_two      = $this->posts['parent_two'];
+		$edit            = $this->posts['edit'];
+		$hidden          = $this->posts['hidden'];
+		$google          = $this->posts['google'];
+		$last_page       = $this->posts['last_page'];
 		$grandchild_one  = $this->posts['grandchild_one'];
 		$grandchild_two  = $this->posts['grandchild_two'];
 		$greatgrandchild = $this->posts['greatgrandchild'];
-		$test   		 = $this->posts['test'];
-		$test_child		 = $this->posts['test_child'];
+		$test            = $this->posts['test'];
+		$test_child      = $this->posts['test_child'];
 		$test_grandchild = $this->posts['test_grandchild'];
 
-		$all_pages 	  = bu_navigation_get_pages();
+		$all_pages    = bu_navigation_get_pages();
 		$page_results = bu_navigation_pages_by_parent( $all_pages );
 
 		// Reorder the pages
-		$page_results[0][4]->menu_order = "1"; // Last
-		$page_results[0][2]->menu_order = "2"; // Edit
-		$page_results[0][1]->menu_order = "3"; // Parent Two
-		$page_results[0][0]->menu_order = "4"; // Parent One
-		$page_results[0][3]->menu_order = "5"; // Google
+		$page_results[0][4]->menu_order = '1'; // Last
+		$page_results[0][2]->menu_order = '2'; // Edit
+		$page_results[0][1]->menu_order = '3'; // Parent Two
+		$page_results[0][0]->menu_order = '4'; // Parent One
+		$page_results[0][3]->menu_order = '5'; // Google
 
 		$sorted_expected = array(
-					(string)$last_page,
-					(string)$edit,
-					(string)$parent_two,
-					(string)$parent,
-					(string)$google,
-					(string)$child,
-					(string)$grandchild_one,
-					(string)$grandchild_two,
-					(string)$greatgrandchild
-				);
+			(string) $last_page,
+			(string) $edit,
+			(string) $parent_two,
+			(string) $parent,
+			(string) $google,
+			(string) $child,
+			(string) $grandchild_one,
+			(string) $grandchild_two,
+			(string) $greatgrandchild,
+		);
 
 		$all_pages_sorted = bu_navigation_pages_by_parent_menu_sort( $page_results );
-		$sorted_results = array();
+		$sorted_results   = array();
 
-		foreach( $all_pages_sorted as $page ) {
-			foreach( $page as $p ) {
+		foreach ( $all_pages_sorted as $page ) {
+			foreach ( $page as $p ) {
 				array_push( $sorted_results, $p->ID );
 			}
 		}
@@ -848,8 +1025,8 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 	 */
 	public function test_bu_navigation_pages_by_parent_menu_sort_cb() {
 
-		$a = (object)array( 'menu_order' => 1 );
-		$b = (object)array( 'menu_order' => 4 );
+		$a = (object) array( 'menu_order' => 1 );
+		$b = (object) array( 'menu_order' => 4 );
 
 		$sorted_val_one = bu_navigation_pages_by_parent_menu_sort_cb( $a, $b );
 		$sorted_val_two = bu_navigation_pages_by_parent_menu_sort_cb( $b, $a );
@@ -870,12 +1047,12 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 
 		// Get parent page details
 		$parent = $this->posts['parent'];
-		$pages = bu_navigation_get_pages();
-		$page = $pages[ $parent ];
+		$pages  = bu_navigation_get_pages();
+		$page   = $pages[ $parent ];
 
 		// Expected formatted results
-		$title = $page->post_title;
-		$url = $page->url;
+		$title                   = $page->post_title;
+		$url                     = $page->url;
 		$expected_formatted_page = '<li class="page_item page-item-' . $parent . '">' . "\n" . '<a href="' . $url . '">' . $title . '</a>' . "\n" . ' </li>' . "\n";
 
 		// Format $parent Page
@@ -888,19 +1065,19 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		*	Test Item Tag Functionaltiy
 		*/
 
-		$args = array( 'item_tag' => 'td' );
-		$formatted_page = bu_navigation_format_page( $page, $args );
-		$expected_formatted_page = sprintf("<td class=\"page_item page-item-%s\">\n<a href=\"%s\">%s</a>\n </td>\n", $parent, $url, $title );
+		$args                    = array( 'item_tag' => 'td' );
+		$formatted_page          = bu_navigation_format_page( $page, $args );
+		$expected_formatted_page = sprintf( "<td class=\"page_item page-item-%s\">\n<a href=\"%s\">%s</a>\n </td>\n", $parent, $url, $title );
 
-		$this->assertEquals( $expected_formatted_page, $formatted_page);
+		$this->assertEquals( $expected_formatted_page, $formatted_page );
 
 		/*
 		*	Test Anchor Class Functionaltiy
 		*/
 
-		$args = array( 'anchor_class' => 'test_class' );
-		$formatted_page = bu_navigation_format_page( $page, $args );
-		$expected_formatted_page = sprintf("<li class=\"page_item page-item-%s\">\n<a class=\"test_class\" href=\"%s\">%s</a>\n </li>\n", $parent, $url, $title );
+		$args                    = array( 'anchor_class' => 'test_class' );
+		$formatted_page          = bu_navigation_format_page( $page, $args );
+		$expected_formatted_page = sprintf( "<li class=\"page_item page-item-%s\">\n<a class=\"test_class\" href=\"%s\">%s</a>\n </li>\n", $parent, $url, $title );
 
 		$this->assertEquals( $expected_formatted_page, $formatted_page );
 
@@ -908,9 +1085,9 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		*	Test Depth Class Functionaltiy
 		*/
 
-		$args = array( 'depth' => 5 );
-		$formatted_page = bu_navigation_format_page( $page, $args );
-		$expected_formatted_page = sprintf("<li class=\"page_item page-item-%s\">\n<a class=\"level_5\" href=\"%s\">%s</a>\n </li>\n", $parent, $url, $title );
+		$args                    = array( 'depth' => 5 );
+		$formatted_page          = bu_navigation_format_page( $page, $args );
+		$expected_formatted_page = sprintf( "<li class=\"page_item page-item-%s\">\n<a class=\"level_5\" href=\"%s\">%s</a>\n </li>\n", $parent, $url, $title );
 
 		$this->assertEquals( $expected_formatted_page, $formatted_page );
 
@@ -918,13 +1095,13 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		*	Test Section ID Functionaltiy
 		*/
 
-		$child = $this->posts['child'];
-		$page_child = $pages[ $child ];
+		$child       = $this->posts['child'];
+		$page_child  = $pages[ $child ];
 		$title_child = $page_child->post_title;
-		$url_child = $page_child->url;
+		$url_child   = $page_child->url;
 
-		$args = array( 'section_ids' => array( $parent, $child ));
-		$formatted_page = bu_navigation_format_page( $page_child, $args );
+		$args                    = array( 'section_ids' => array( $parent, $child ) );
+		$formatted_page          = bu_navigation_format_page( $page_child, $args );
 		$expected_formatted_page = '<li class="page_item page-item-' . $child . ' has_children">' . "\n" . '<a href="' . $url_child . '">' . $title_child . '</a>' . "\n" . ' </li>' . "\n";
 
 		$this->assertEquals( $expected_formatted_page, $formatted_page );
@@ -934,15 +1111,21 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		*/
 
 		// First Item
-		$args = array( 'position' => 1, 'siblings' => 3 );
-		$formatted_page = bu_navigation_format_page( $page, $args );
+		$args                    = array(
+			'position' => 1,
+			'siblings' => 3,
+		);
+		$formatted_page          = bu_navigation_format_page( $page, $args );
 		$expected_formatted_page = '<li class="page_item page-item-' . $parent . ' first_item">' . "\n" . '<a href="' . $url . '">' . $title . '</a>' . "\n" . ' </li>' . "\n";
 
 		$this->assertEquals( $expected_formatted_page, $formatted_page );
 
 		// Last Item
-		$args = array( 'position' => 3, 'siblings' => 3 );
-		$formatted_page = bu_navigation_format_page( $page, $args );
+		$args                    = array(
+			'position' => 3,
+			'siblings' => 3,
+		);
+		$formatted_page          = bu_navigation_format_page( $page, $args );
 		$expected_formatted_page = '<li class="page_item page-item-' . $parent . ' last_item">' . "\n" . '<a href="' . $url . '">' . $title . '</a>' . "\n" . ' </li>' . "\n";
 
 		$this->assertEquals( $expected_formatted_page, $formatted_page );
@@ -951,8 +1134,8 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		*	Test HTML Functionaltiy
 		*/
 
-		$args = array( 'html' => 'some html' );
-		$formatted_page = bu_navigation_format_page( $page, $args );
+		$args                    = array( 'html' => 'some html' );
+		$formatted_page          = bu_navigation_format_page( $page, $args );
 		$expected_formatted_page = '<li class="page_item page-item-' . $parent . '">' . "\n" . '<a href="' . $url . '">' . $title . '</a>' . "\n" . ' some html</li>' . "\n";
 
 		$this->assertEquals( $expected_formatted_page, $formatted_page );
@@ -961,16 +1144,19 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		*	Test ID Functionaltiy
 		*/
 
-		$args = array( 'item_id' => 'test_item_id' );
-		$formatted_page = bu_navigation_format_page( $page, $args );
+		$args                    = array( 'item_id' => 'test_item_id' );
+		$formatted_page          = bu_navigation_format_page( $page, $args );
 		$expected_formatted_page = '<li id="test_item_id" class="page_item page-item-' . $parent . '">' . "\n" . '<a href="' . $url . '">' . $title . '</a>' . "\n" . ' </li>' . "\n";
 
 		/*
 		*	Test title before/after Functionaltiy
 		*/
 
-		$args = array( 'title_before' => '<span>', 'title_after' => '</span>', );
-		$formatted_page = bu_navigation_format_page( $page, $args );
+		$args                    = array(
+			'title_before' => '<span>',
+			'title_after'  => '</span>',
+		);
+		$formatted_page          = bu_navigation_format_page( $page, $args );
 		$expected_formatted_page = '<li class="page_item page-item-' . $parent . '">' . "\n" . '<a href="' . $url . '"><span>' . $title . '</span></a>' . "\n" . ' </li>' . "\n";
 
 		$this->assertEquals( $expected_formatted_page, $formatted_page );
@@ -982,67 +1168,67 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 	 */
 	public function test_bu_navigation_filter_item_attrs() {
 
-		$parent = $this->posts['parent'];
-		$child = $this->posts['child'];
+		$parent         = $this->posts['parent'];
+		$child          = $this->posts['child'];
 		$grandchild_one = $this->posts['grandchild_one'];
-		$parent_two = $this->posts['parent_two'];
+		$parent_two     = $this->posts['parent_two'];
 
 		/**
-		* 	 Parent Page link on the Parent Page
+		*    Parent Page link on the Parent Page
 		*/
 
-		$this->go_to( get_permalink( $parent ));
+		$this->go_to( get_permalink( $parent ) );
 
-		$pages = bu_navigation_get_pages();
-		$page = $pages[ $parent ];
-		$item_classes = array('page_item', 'page-item-' . $page->ID);
+		$pages        = bu_navigation_get_pages();
+		$page         = $pages[ $parent ];
+		$item_classes = array( 'page_item', 'page-item-' . $page->ID );
 
-		$parent_expected = array('page_item', 'page-item-' . $page->ID, "current_page_item");
-		$parent_results = apply_filters( 'bu_navigation_filter_item_attrs', $item_classes, $page );
+		$parent_expected = array( 'page_item', 'page-item-' . $page->ID, 'current_page_item' );
+		$parent_results  = apply_filters( 'bu_navigation_filter_item_attrs', $item_classes, $page );
 		$this->assertEquals( $parent_results, $parent_expected );
 
 		/**
-		* 	 Parent Page Link on the Child Page
+		*    Parent Page Link on the Child Page
 		*/
 
-		$this->go_to( get_permalink( $child ));
+		$this->go_to( get_permalink( $child ) );
 
-		$pages = bu_navigation_get_pages();
-		$page = $pages[ $parent ];
-		$item_classes = array('page_item', 'page-item-' . $page->ID);
+		$pages        = bu_navigation_get_pages();
+		$page         = $pages[ $parent ];
+		$item_classes = array( 'page_item', 'page-item-' . $page->ID );
 
-		$child_expected = array('page_item', 'page-item-' . $page->ID, "current_page_ancestor", "current_page_parent");
-		$child_results = apply_filters( 'bu_navigation_filter_item_attrs', $item_classes, $page );
+		$child_expected = array( 'page_item', 'page-item-' . $page->ID, 'current_page_ancestor', 'current_page_parent' );
+		$child_results  = apply_filters( 'bu_navigation_filter_item_attrs', $item_classes, $page );
 
 		$this->assertEquals( $child_results, $child_expected );
 
 		/**
-		* 	 Parent Page Link on the Grandchild Page
+		*    Parent Page Link on the Grandchild Page
 		*/
 
-		$this->go_to( get_permalink( $grandchild_one ));
+		$this->go_to( get_permalink( $grandchild_one ) );
 
-		$pages = bu_navigation_get_pages();
-		$page = $pages[ $parent ];
-		$item_classes = array('page_item', 'page-item-' . $page->ID);
+		$pages        = bu_navigation_get_pages();
+		$page         = $pages[ $parent ];
+		$item_classes = array( 'page_item', 'page-item-' . $page->ID );
 
-		$grandchild_expected = array('page_item', 'page-item-' . $page->ID, "current_page_ancestor");
-		$grandchild_results = apply_filters( 'bu_navigation_filter_item_attrs', $item_classes, $page );
+		$grandchild_expected = array( 'page_item', 'page-item-' . $page->ID, 'current_page_ancestor' );
+		$grandchild_results  = apply_filters( 'bu_navigation_filter_item_attrs', $item_classes, $page );
 
 		$this->assertEquals( $grandchild_results, $grandchild_expected );
 
 		/**
-		* 	 Child Page Link on the Parent Page Two (unrelated page)
+		*    Child Page Link on the Parent Page Two (unrelated page)
 		*/
 
-		$this->go_to( get_permalink( $parent_two ));
+		$this->go_to( get_permalink( $parent_two ) );
 
-		$pages = bu_navigation_get_pages();
-		$page = $pages[ $child ];
-		$item_classes = array('page_item', 'page-item-' . $page->ID);
+		$pages        = bu_navigation_get_pages();
+		$page         = $pages[ $child ];
+		$item_classes = array( 'page_item', 'page-item-' . $page->ID );
 
-		$parent_two_expected = array('page_item', 'page-item-' . $page->ID );
-		$parent_two_results = apply_filters( 'bu_navigation_filter_item_attrs', $item_classes, $page );
+		$parent_two_expected = array( 'page_item', 'page-item-' . $page->ID );
+		$parent_two_results  = apply_filters( 'bu_navigation_filter_item_attrs', $item_classes, $page );
 
 		$this->assertEquals( $parent_two_expected, $parent_two_results );
 
@@ -1053,49 +1239,49 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 	 */
 	public function test_bu_navigation_filter_item_active_page() {
 
-		$parent = $this->posts['parent'];
-		$child = $this->posts['child'];
+		$parent         = $this->posts['parent'];
+		$child          = $this->posts['child'];
 		$grandchild_one = $this->posts['grandchild_one'];
-		$parent_two = $this->posts['parent_two'];
+		$parent_two     = $this->posts['parent_two'];
 
 		/**
-		* 	 Parent Page Link on the Parent Page
+		*    Parent Page Link on the Parent Page
 		*/
 
-		$this->go_to( get_permalink( $parent ));
+		$this->go_to( get_permalink( $parent ) );
 
-		$pages = bu_navigation_get_pages();
-		$page = $pages[ $parent ];
+		$pages           = bu_navigation_get_pages();
+		$page            = $pages[ $parent ];
 		$parent_expected = array( 'class' => '' );
 
-		$parent_results = apply_filters( 'bu_navigation_filter_anchor_attrs', $parent_expected, $page );
+		$parent_results           = apply_filters( 'bu_navigation_filter_anchor_attrs', $parent_expected, $page );
 		$parent_expected['class'] = ' active';
 
 		$this->assertEquals( $parent_expected, $parent_results );
 
 		/**
-		* 	 Parent Page Link on the Child Page
+		*    Parent Page Link on the Child Page
 		*/
 
-		$this->go_to( get_permalink( $child ));
+		$this->go_to( get_permalink( $child ) );
 
-		$pages = bu_navigation_get_pages();
-		$page = $pages[ $parent ];
+		$pages          = bu_navigation_get_pages();
+		$page           = $pages[ $parent ];
 		$child_expected = array( 'class' => '' );
 
-		$child_results = apply_filters( 'bu_navigation_filter_anchor_attrs', $child_expected, $page );
+		$child_results           = apply_filters( 'bu_navigation_filter_anchor_attrs', $child_expected, $page );
 		$child_expected['class'] = ' active_section';
 
 		$this->assertEquals( $child_expected, $child_results );
 
 		/**
-		* 	 Parent Page Two Link on the Child Page (Unrelated)
+		*    Parent Page Two Link on the Child Page (Unrelated)
 		*/
 
-		$this->go_to( get_permalink( $child ));
+		$this->go_to( get_permalink( $child ) );
 
-		$pages = bu_navigation_get_pages();
-		$page = $pages[ $parent_two ];
+		$pages               = bu_navigation_get_pages();
+		$page                = $pages[ $parent_two ];
 		$parent_two_expected = array( 'class' => '' );
 
 		$parent_two_results = apply_filters( 'bu_navigation_filter_anchor_attrs', $parent_two_expected, $page );
@@ -1109,50 +1295,50 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 	 */
 	public function test_bu_navigation_list_section() {
 
-		$parent			 = $this->posts['parent'];
-		$child 			 = $this->posts['child'];
+		$parent          = $this->posts['parent'];
+		$child           = $this->posts['child'];
 		$grandchild_one  = $this->posts['grandchild_one'];
 		$grandchild_two  = $this->posts['grandchild_two'];
 		$greatgrandchild = $this->posts['greatgrandchild'];
-		$pages 			 = bu_navigation_get_pages();
+		$pages           = bu_navigation_get_pages();
 		$pages_by_parent = bu_navigation_pages_by_parent( $pages );
 
 		// Generate Expected Results - Child Section
 		$child_section_expected = "\n<ul>\n" .
 				'<li class="page_item page-item-' . $grandchild_one . '">' . "\n" .
-				'<a class="level_1" href="' . $pages[$grandchild_one]->url . '">'. $pages[$grandchild_one]->post_title . '</a>' . "\n \n" .
+				'<a class="level_1" href="' . $pages[ $grandchild_one ]->url . '">' . $pages[ $grandchild_one ]->post_title . '</a>' . "\n \n" .
 				"<ul>\n" .
 				'<li class="page_item page-item-' . $greatgrandchild . '">' . "\n" .
-				'<a class="level_2" href="' . $pages[$greatgrandchild]->url . '">' . $pages[$greatgrandchild]->post_title . '</a>' . "\n" .
+				'<a class="level_2" href="' . $pages[ $greatgrandchild ]->url . '">' . $pages[ $greatgrandchild ]->post_title . '</a>' . "\n" .
 				" </li>\n\n" .
 				"</ul>\n" .
 				"</li>\n" .
 				'<li class="page_item page-item-' . $grandchild_two . '">' . "\n" .
-				'<a class="level_1" href="' . $pages[$grandchild_two]->url . '">' . $pages[$grandchild_two]->post_title . '</a>' . "\n" .
+				'<a class="level_1" href="' . $pages[ $grandchild_two ]->url . '">' . $pages[ $grandchild_two ]->post_title . '</a>' . "\n" .
 				" </li>\n\n" .
 				"</ul>\n";
 
 		// Generate Expected Results - Parent Section
 		$parent_section_expected = "\n<ul>\n" .
 				'<li class="page_item page-item-' . $child . '">' . "\n" .
-				'<a class="level_1" href="' . $pages[$child]->url . '">'. $pages[$child]->post_title . '</a>' . "\n \n" .
+				'<a class="level_1" href="' . $pages[ $child ]->url . '">' . $pages[ $child ]->post_title . '</a>' . "\n \n" .
 				"<ul>\n" .
 				'<li class="page_item page-item-' . $grandchild_one . '">' . "\n" .
-				'<a class="level_2" href="' . $pages[$grandchild_one]->url . '">' . $pages[$grandchild_one]->post_title . '</a>' . "\n \n" .
+				'<a class="level_2" href="' . $pages[ $grandchild_one ]->url . '">' . $pages[ $grandchild_one ]->post_title . '</a>' . "\n \n" .
 				"<ul>\n" .
 				'<li class="page_item page-item-' . $greatgrandchild . '">' . "\n" .
-				'<a class="level_3" href="' . $pages[$greatgrandchild]->url . '">' . $pages[$greatgrandchild]->post_title . '</a>' . "\n" .
+				'<a class="level_3" href="' . $pages[ $greatgrandchild ]->url . '">' . $pages[ $greatgrandchild ]->post_title . '</a>' . "\n" .
 				" </li>\n\n" .
 				"</ul>\n" .
 				"</li>\n" .
 				'<li class="page_item page-item-' . $grandchild_two . '">' . "\n" .
-				'<a class="level_2" href="' . $pages[$grandchild_two]->url . '">' . $pages[$grandchild_two]->post_title . '</a>' . "\n" .
+				'<a class="level_2" href="' . $pages[ $grandchild_two ]->url . '">' . $pages[ $grandchild_two ]->post_title . '</a>' . "\n" .
 				" </li>\n\n" .
 				"</ul>\n</li>\n\n" .
 				"</ul>\n";
 
 		// Get Results
-		$child_section_results = bu_navigation_list_section( $child, $pages_by_parent );
+		$child_section_results  = bu_navigation_list_section( $child, $pages_by_parent );
 		$parent_section_results = bu_navigation_list_section( $parent, $pages_by_parent );
 
 		// Test Results
@@ -1160,106 +1346,106 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		$this->assertEquals( $parent_section_expected, $parent_section_results );
 
 		/**
-		* 	Test Depth Functionaltiy
+		*   Test Depth Functionaltiy
 		*/
 
 		$parent_section_depth_expected = "\n<ul>\n" .
 				'<li class="page_item page-item-' . $child . '">' . "\n" .
-				'<a class="level_3" href="' . $pages[$child]->url . '">'. $pages[$child]->post_title . '</a>' . "\n \n" .
+				'<a class="level_3" href="' . $pages[ $child ]->url . '">' . $pages[ $child ]->post_title . '</a>' . "\n \n" .
 				"<ul>\n" .
 				'<li class="page_item page-item-' . $grandchild_one . '">' . "\n" .
-				'<a class="level_4" href="' . $pages[$grandchild_one]->url . '">' . $pages[$grandchild_one]->post_title . '</a>' . "\n \n" .
+				'<a class="level_4" href="' . $pages[ $grandchild_one ]->url . '">' . $pages[ $grandchild_one ]->post_title . '</a>' . "\n \n" .
 				"<ul>\n" .
 				'<li class="page_item page-item-' . $greatgrandchild . '">' . "\n" .
-				'<a class="level_5" href="' . $pages[$greatgrandchild]->url . '">' . $pages[$greatgrandchild]->post_title . '</a>' . "\n" .
+				'<a class="level_5" href="' . $pages[ $greatgrandchild ]->url . '">' . $pages[ $greatgrandchild ]->post_title . '</a>' . "\n" .
 				" </li>\n\n" .
 				"</ul>\n" .
 				"</li>\n" .
 				'<li class="page_item page-item-' . $grandchild_two . '">' . "\n" .
-				'<a class="level_4" href="' . $pages[$grandchild_two]->url . '">' . $pages[$grandchild_two]->post_title . '</a>' . "\n" .
+				'<a class="level_4" href="' . $pages[ $grandchild_two ]->url . '">' . $pages[ $grandchild_two ]->post_title . '</a>' . "\n" .
 				" </li>\n\n" .
 				"</ul>\n</li>\n\n" .
 				"</ul>\n";
 
-		$args = array( 'depth' => 3 );
+		$args                         = array( 'depth' => 3 );
 		$parent_section_depth_results = bu_navigation_list_section( $parent, $pages_by_parent, $args );
 		$this->assertEquals( $parent_section_depth_expected, $parent_section_depth_results );
 
 		/**
-		* 	Test Container Tag Functionaltiy
+		*   Test Container Tag Functionaltiy
 		*/
 
 		$parent_section_container_tag_expected = "\n<ol>\n" .
 				'<li class="page_item page-item-' . $child . '">' . "\n" .
-				'<a class="level_1" href="' . $pages[$child]->url . '">'. $pages[$child]->post_title . '</a>' . "\n \n" .
+				'<a class="level_1" href="' . $pages[ $child ]->url . '">' . $pages[ $child ]->post_title . '</a>' . "\n \n" .
 				"<ol>\n" .
 				'<li class="page_item page-item-' . $grandchild_one . '">' . "\n" .
-				'<a class="level_2" href="' . $pages[$grandchild_one]->url . '">' . $pages[$grandchild_one]->post_title . '</a>' . "\n \n" .
+				'<a class="level_2" href="' . $pages[ $grandchild_one ]->url . '">' . $pages[ $grandchild_one ]->post_title . '</a>' . "\n \n" .
 				"<ol>\n" .
 				'<li class="page_item page-item-' . $greatgrandchild . '">' . "\n" .
-				'<a class="level_3" href="' . $pages[$greatgrandchild]->url . '">' . $pages[$greatgrandchild]->post_title . '</a>' . "\n" .
+				'<a class="level_3" href="' . $pages[ $greatgrandchild ]->url . '">' . $pages[ $greatgrandchild ]->post_title . '</a>' . "\n" .
 				" </li>\n\n" .
 				"</ol>\n" .
 				"</li>\n" .
 				'<li class="page_item page-item-' . $grandchild_two . '">' . "\n" .
-				'<a class="level_2" href="' . $pages[$grandchild_two]->url . '">' . $pages[$grandchild_two]->post_title . '</a>' . "\n" .
+				'<a class="level_2" href="' . $pages[ $grandchild_two ]->url . '">' . $pages[ $grandchild_two ]->post_title . '</a>' . "\n" .
 				" </li>\n\n" .
 				"</ol>\n</li>\n\n" .
 				"</ol>\n";
 
-		$args = array( 'container_tag' => 'ol' );
+		$args                                 = array( 'container_tag' => 'ol' );
 		$parent_section_container_tag_results = bu_navigation_list_section( $parent, $pages_by_parent, $args );
 		$this->assertEquals( $parent_section_container_tag_expected, $parent_section_container_tag_results );
 
 		/**
-		* 	Test Item Tag Functionaltiy
+		*   Test Item Tag Functionaltiy
 		*/
 
 		$parent_section_item_tag_expected = "\n<ul>\n" .
 				'<test class="page_item page-item-' . $child . '">' . "\n" .
-				'<a class="level_1" href="' . $pages[$child]->url . '">'. $pages[$child]->post_title . '</a>' . "\n \n" .
+				'<a class="level_1" href="' . $pages[ $child ]->url . '">' . $pages[ $child ]->post_title . '</a>' . "\n \n" .
 				"<ul>\n" .
 				'<test class="page_item page-item-' . $grandchild_one . '">' . "\n" .
-				'<a class="level_2" href="' . $pages[$grandchild_one]->url . '">' . $pages[$grandchild_one]->post_title . '</a>' . "\n \n" .
+				'<a class="level_2" href="' . $pages[ $grandchild_one ]->url . '">' . $pages[ $grandchild_one ]->post_title . '</a>' . "\n \n" .
 				"<ul>\n" .
 				'<test class="page_item page-item-' . $greatgrandchild . '">' . "\n" .
-				'<a class="level_3" href="' . $pages[$greatgrandchild]->url . '">' . $pages[$greatgrandchild]->post_title . '</a>' . "\n" .
+				'<a class="level_3" href="' . $pages[ $greatgrandchild ]->url . '">' . $pages[ $greatgrandchild ]->post_title . '</a>' . "\n" .
 				" </test>\n\n" .
 				"</ul>\n" .
 				"</test>\n" .
 				'<test class="page_item page-item-' . $grandchild_two . '">' . "\n" .
-				'<a class="level_2" href="' . $pages[$grandchild_two]->url . '">' . $pages[$grandchild_two]->post_title . '</a>' . "\n" .
+				'<a class="level_2" href="' . $pages[ $grandchild_two ]->url . '">' . $pages[ $grandchild_two ]->post_title . '</a>' . "\n" .
 				" </test>\n\n" .
 				"</ul>\n</test>\n\n" .
 				"</ul>\n";
 
-		$args = array( 'item_tag' => 'test' );
+		$args                            = array( 'item_tag' => 'test' );
 		$parent_section_item_tag_results = bu_navigation_list_section( $parent, $pages_by_parent, $args );
 		$this->assertEquals( $parent_section_item_tag_expected, $parent_section_item_tag_results );
 
 		/**
-		* 	Test Section Ids Functionaltiy
+		*   Test Section Ids Functionaltiy
 		*/
 
 		$parent_section_section_id_expected = "\n<ul>\n" .
 				'<li class="page_item page-item-' . $child . ' has_children">' . "\n" .
-				'<a class="level_1" href="' . $pages[$child]->url . '">'. $pages[$child]->post_title . '</a>' . "\n \n" .
+				'<a class="level_1" href="' . $pages[ $child ]->url . '">' . $pages[ $child ]->post_title . '</a>' . "\n \n" .
 				"<ul>\n" .
 				'<li class="page_item page-item-' . $grandchild_one . ' has_children">' . "\n" .
-				'<a class="level_2" href="' . $pages[$grandchild_one]->url . '">' . $pages[$grandchild_one]->post_title . '</a>' . "\n \n" .
+				'<a class="level_2" href="' . $pages[ $grandchild_one ]->url . '">' . $pages[ $grandchild_one ]->post_title . '</a>' . "\n \n" .
 				"<ul>\n" .
 				'<li class="page_item page-item-' . $greatgrandchild . '">' . "\n" .
-				'<a class="level_3" href="' . $pages[$greatgrandchild]->url . '">' . $pages[$greatgrandchild]->post_title . '</a>' . "\n" .
+				'<a class="level_3" href="' . $pages[ $greatgrandchild ]->url . '">' . $pages[ $greatgrandchild ]->post_title . '</a>' . "\n" .
 				" </li>\n\n" .
 				"</ul>\n" .
 				"</li>\n" .
 				'<li class="page_item page-item-' . $grandchild_two . '">' . "\n" .
-				'<a class="level_2" href="' . $pages[$grandchild_two]->url . '">' . $pages[$grandchild_two]->post_title . '</a>' . "\n" .
+				'<a class="level_2" href="' . $pages[ $grandchild_two ]->url . '">' . $pages[ $grandchild_two ]->post_title . '</a>' . "\n" .
 				" </li>\n\n" .
 				"</ul>\n</li>\n\n" .
 				"</ul>\n";
 
-		$args = array( 'section_ids' => array( $child, $grandchild_one ));
+		$args                              = array( 'section_ids' => array( $child, $grandchild_one ) );
 		$parent_section_section_id_results = bu_navigation_list_section( $parent, $pages_by_parent, $args );
 		$this->assertEquals( $parent_section_section_id_expected, $parent_section_section_id_results );
 
@@ -1270,18 +1456,18 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 	 */
 	public function test_bu_navigation_list_pages() {
 
-		$parent 		 = $this->posts['parent'];
-		$child 			 = $this->posts['child'];
-		$parent_two 	 = $this->posts['parent_two'];
-		$hidden 		 = $this->posts['hidden'];
-		$edit 			 = $this->posts['edit'];
-		$google 		 = $this->posts['google'];
-		$last_page		 = $this->posts['last_page'];
+		$parent          = $this->posts['parent'];
+		$child           = $this->posts['child'];
+		$parent_two      = $this->posts['parent_two'];
+		$hidden          = $this->posts['hidden'];
+		$edit            = $this->posts['edit'];
+		$google          = $this->posts['google'];
+		$last_page       = $this->posts['last_page'];
 		$grandchild_one  = $this->posts['grandchild_one'];
 		$grandchild_two  = $this->posts['grandchild_two'];
 		$greatgrandchild = $this->posts['greatgrandchild'];
-		$test   		 = $this->posts['test'];
-		$test_child		 = $this->posts['test_child'];
+		$test            = $this->posts['test'];
+		$test_child      = $this->posts['test_child'];
 		$test_grandchild = $this->posts['test_grandchild'];
 
 		$list_pages_expected = "<ul >\n" .
@@ -1299,7 +1485,7 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 			" </li>\n\n" .
 			"</ul>\n" .
 			"</li>\n" .
-			'<li class="page_item page-item-' . $grandchild_two . '">' . "\n".
+			'<li class="page_item page-item-' . $grandchild_two . '">' . "\n" .
 			'<a class="level_3" href="' . get_permalink( $grandchild_two ) . '">Grand Child Page 2</a>' . "\n" .
 			" </li>\n\n" .
 			"</ul>\n" .
@@ -1324,7 +1510,7 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		$this->assertEquals( $list_pages_expected, $list_pages_results );
 
 		/**
-		* 	Test Page ID Function
+		*   Test Page ID Function
 		*/
 
 		$list_pages_page_id_expected = "<ul >\n" .
@@ -1350,12 +1536,12 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 			" </li>\n" .
 			"</ul>\n";
 
-		$args = array( 'page_id' => $parent );
+		$args                       = array( 'page_id' => $parent );
 		$list_pages_page_id_results = bu_navigation_list_pages( $args );
 		$this->assertEquals( $list_pages_page_id_expected, $list_pages_page_id_results );
 
 		/**
-		* 	Test Echo Function
+		*   Test Echo Function
 		*/
 
 		ob_start();
@@ -1367,7 +1553,7 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		$this->assertEquals( $list_pages_expected, $list_pages_echo_results );
 
 		/**
-		* 	Test Navigate in Section Function
+		*   Test Navigate in Section Function
 		*/
 
 		$list_pages_navigate_in_section_expected = "<ul >\n" .
@@ -1382,19 +1568,19 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 			" </li>\n\n" .
 			"</ul>\n" .
 			"</li>\n" .
-			'<li class="page_item page-item-' . $grandchild_two . '">' . "\n".
+			'<li class="page_item page-item-' . $grandchild_two . '">' . "\n" .
 			'<a class="level_2" href="' . get_permalink( $grandchild_two ) . '">Grand Child Page 2</a>' . "\n" .
 			" </li>\n\n" .
 			"</ul>\n" .
 			"</li>\n" .
 			"</ul>\n";
 
-		$args = array( 'navigate_in_section' => true );
+		$args                                   = array( 'navigate_in_section' => true );
 		$list_pages_navigate_in_section_results = bu_navigation_list_pages( $args );
 		$this->assertEquals( $list_pages_navigate_in_section_expected, $list_pages_navigate_in_section_results );
 
 		/**
-		* 	Test Container Tag Function
+		*   Test Container Tag Function
 		*/
 
 		$list_pages_container_tag_expected = "<ol >\n" .
@@ -1412,7 +1598,7 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 			" </li>\n\n" .
 			"</ol>\n" .
 			"</li>\n" .
-			'<li class="page_item page-item-' . $grandchild_two . '">' . "\n".
+			'<li class="page_item page-item-' . $grandchild_two . '">' . "\n" .
 			'<a class="level_3" href="' . get_permalink( $grandchild_two ) . '">Grand Child Page 2</a>' . "\n" .
 			" </li>\n\n" .
 			"</ol>\n" .
@@ -1433,12 +1619,12 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 			" </li>\n" .
 			"</ol>\n";
 
-		$args = array( 'container_tag' => 'ol' );
+		$args                             = array( 'container_tag' => 'ol' );
 		$list_pages_container_tag_results = bu_navigation_list_pages( $args );
 		$this->assertEquals( $list_pages_container_tag_expected, $list_pages_container_tag_results );
 
 		/**
-		* 	Test Container ID Function
+		*   Test Container ID Function
 		*/
 
 		$list_pages_container_id_expected = '<ul  id="test_container_id">' . "\n" .
@@ -1456,7 +1642,7 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 			" </li>\n\n" .
 			"</ul>\n" .
 			"</li>\n" .
-			'<li class="page_item page-item-' . $grandchild_two . '">' . "\n".
+			'<li class="page_item page-item-' . $grandchild_two . '">' . "\n" .
 			'<a class="level_3" href="' . get_permalink( $grandchild_two ) . '">Grand Child Page 2</a>' . "\n" .
 			" </li>\n\n" .
 			"</ul>\n" .
@@ -1477,13 +1663,12 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 			" </li>\n" .
 			"</ul>\n";
 
-		$args = array( 'container_id' => 'test_container_id' );
+		$args                            = array( 'container_id' => 'test_container_id' );
 		$list_pages_container_id_results = bu_navigation_list_pages( $args );
 		$this->assertEquals( $list_pages_container_id_expected, $list_pages_container_id_results );
 
-
 		/**
-		* 	Test Container Class Function
+		*   Test Container Class Function
 		*/
 
 		$list_pages_container_class_expected = '<ul  class="test_container_class">' . "\n" .
@@ -1501,7 +1686,7 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 			" </li>\n\n" .
 			"</ul>\n" .
 			"</li>\n" .
-			'<li class="page_item page-item-' . $grandchild_two . '">' . "\n".
+			'<li class="page_item page-item-' . $grandchild_two . '">' . "\n" .
 			'<a class="level_3" href="' . get_permalink( $grandchild_two ) . '">Grand Child Page 2</a>' . "\n" .
 			" </li>\n\n" .
 			"</ul>\n" .
@@ -1522,12 +1707,12 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 			" </li>\n" .
 			"</ul>\n";
 
-		$args = array( 'container_class' => 'test_container_class' );
+		$args                               = array( 'container_class' => 'test_container_class' );
 		$list_pages_container_class_results = bu_navigation_list_pages( $args );
 		$this->assertEquals( $list_pages_container_class_expected, $list_pages_container_class_results );
 
 		/**
-		* 	Test Item Tag Function
+		*   Test Item Tag Function
 		*/
 
 		$list_pages_item_tag_expected = "<ul >\n" .
@@ -1545,7 +1730,7 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 			" </ll>\n\n" .
 			"</ul>\n" .
 			"</ll>\n" .
-			'<ll class="page_item page-item-' . $grandchild_two . '">' . "\n".
+			'<ll class="page_item page-item-' . $grandchild_two . '">' . "\n" .
 			'<a class="level_3" href="' . get_permalink( $grandchild_two ) . '">Grand Child Page 2</a>' . "\n" .
 			" </ll>\n\n" .
 			"</ul>\n" .
@@ -1566,12 +1751,12 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 			" </ll>\n" .
 			"</ul>\n";
 
-		$args = array( 'item_tag' => 'll' );
+		$args                        = array( 'item_tag' => 'll' );
 		$list_pages_item_tag_results = bu_navigation_list_pages( $args );
 		$this->assertEquals( $list_pages_item_tag_expected, $list_pages_item_tag_results );
 
 		/**
-		* 	Test Style (Adaptive) Function
+		*   Test Style (Adaptive) Function
 		*/
 
 		$list_pages_style_expected = "<ul >\n" .
@@ -1581,19 +1766,22 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 			'<li class="page_item page-item-' . $grandchild_one . ' has_children">' . "\n" .
 			'<a class="level_2" href="' . get_permalink( $grandchild_one ) . '">Grand Child Page 1</a>' . "\n" .
 			" </li>\n" .
-			'<li class="page_item page-item-' . $grandchild_two . '">' . "\n".
+			'<li class="page_item page-item-' . $grandchild_two . '">' . "\n" .
 			'<a class="level_2" href="' . get_permalink( $grandchild_two ) . '">Grand Child Page 2</a>' . "\n" .
 			" </li>\n\n" .
 			"</ul>\n" .
 			"</li>\n" .
 			"</ul>\n";
 
-		$args = array( 'page_id' => $child, 'style' => 'adaptive' );
+		$args                     = array(
+			'page_id' => $child,
+			'style'   => 'adaptive',
+		);
 		$list_pages_style_results = bu_navigation_list_pages( $args );
 		$this->assertEquals( $list_pages_style_expected, $list_pages_style_results );
 
 		/**
-		* 	Test Post Types Function
+		*   Test Post Types Function
 		*/
 		$list_pages_post_type_expected = "<ul >\n" .
 			'<li class="page_item page-item-' . $test . ' first_item last_item">' . "\n" .
@@ -1602,7 +1790,7 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 			'<li class="page_item page-item-' . $test_child . '">' . "\n" .
 			'<a class="level_2" href="' . get_permalink( $test_child ) . '">Test Child</a>' . "\n \n" .
 			"<ul>\n" .
-			'<li class="page_item page-item-' . $test_grandchild . '">' . "\n".
+			'<li class="page_item page-item-' . $test_grandchild . '">' . "\n" .
 			'<a class="level_3" href="' . get_permalink( $test_grandchild ) . '">Test Grandchild</a>' . "\n" .
 			" </li>\n\n" .
 			"</ul>\n" .
@@ -1611,7 +1799,7 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 			"</li>\n" .
 			"</ul>\n";
 
-		$args = array( 'post_types' => array( 'test' ));
+		$args                         = array( 'post_types' => array( 'test' ) );
 		$list_pages_post_type_results = bu_navigation_list_pages( $args );
 		$this->assertEquals( $list_pages_post_type_expected, $list_pages_post_type_results );
 
@@ -1622,9 +1810,9 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 	 */
 	public function test_bu_navigation_page_parent_dropdown() {
 
-		$parent = $this->posts['parent'];
-		$child = $this->posts['child'];
-		$test = $this->posts['test'];
+		$parent     = $this->posts['parent'];
+		$child      = $this->posts['child'];
+		$test       = $this->posts['test'];
 		$post_types = 'page';
 
 		$dropdown_expected = "<select id=\"bu_filter_pages\" name=\"post_parent\">\r" .
@@ -1640,10 +1828,10 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		$this->assertEquals( $dropdown_expected, $dropdown_results );
 
 		/**
-		*	Test Post Type Function
+		*   Test Post Type Function
 		*/
 
-		$post_types_test = 'test';
+		$post_types_test            = 'test';
 		$dropdown_posttype_expected = "<select id=\"bu_filter_pages\" name=\"post_parent\">\r" .
 				"\n\t<option value=\"" . $test . "\" >Test Type Page</option>\r" .
 				"\r</select>\r";
@@ -1656,10 +1844,10 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		$this->assertEquals( $dropdown_posttype_expected, $dropdown_posttype_expected );
 
 		/**
-		*	Test Selected Function
+		*   Test Selected Function
 		*/
 
-		$selected = $parent;
+		$selected                   = $parent;
 		$dropdown_selected_expected = "<select id=\"bu_filter_pages\" name=\"post_parent\">\r" .
 				"\n\t<option value=\"0\">Show all sections</option>\r" .
 				"\n\t<option value=\"" . $parent . "\" selected=\"selected\">Parent Page</option>\r" .
@@ -1673,7 +1861,7 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		$this->assertEquals( $dropdown_selected_expected, $dropdown_selected_results );
 
 		/**
-		*	Test Echo Function
+		*   Test Echo Function
 		*/
 
 		$dropdown_echo_expected = "<select id=\"bu_filter_pages\" name=\"post_parent\">\r" .
@@ -1681,13 +1869,13 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 				"\n\t<option value=\"" . $parent . "\" >Parent Page</option>\r" .
 				"\r</select>\r";
 
-		$args = array( 'echo' => 0 );
+		$args                  = array( 'echo' => 0 );
 		$dropdown_echo_results = bu_navigation_page_parent_dropdown( $post_types, 0, $args );
 
 		$this->assertEquals( $dropdown_echo_expected, $dropdown_echo_results );
 
 		/**
-		*	Test Select ID Function
+		*   Test Select ID Function
 		*/
 
 		$dropdown_select_id_expected = "<select id=\"test_select_id\" name=\"post_parent\">\r" .
@@ -1695,13 +1883,16 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 				"\n\t<option value=\"" . $parent . "\" >Parent Page</option>\r" .
 				"\r</select>\r";
 
-		$args = array( 'echo' => 0, 'select_id' => 'test_select_id' );
+		$args                       = array(
+			'echo'      => 0,
+			'select_id' => 'test_select_id',
+		);
 		$dropdown_select_id_results = bu_navigation_page_parent_dropdown( $post_types, 0, $args );
 
 		$this->assertEquals( $dropdown_select_id_expected, $dropdown_select_id_results );
 
 		/**
-		*	Test Select Name Function
+		*   Test Select Name Function
 		*/
 
 		$dropdown_select_name_expected = "<select id=\"bu_filter_pages\" name=\"test_name\">\r" .
@@ -1709,13 +1900,16 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 				"\n\t<option value=\"" . $parent . "\" >Parent Page</option>\r" .
 				"\r</select>\r";
 
-		$args = array( 'echo' => 0, 'select_name' => 'test_name' );
+		$args                         = array(
+			'echo'        => 0,
+			'select_name' => 'test_name',
+		);
 		$dropdown_select_name_results = bu_navigation_page_parent_dropdown( $post_types, 0, $args );
 
 		$this->assertEquals( $dropdown_select_name_expected, $dropdown_select_name_results );
 
 		/**
-		*	Test Select Classes Function
+		*   Test Select Classes Function
 		*/
 
 		$dropdown_classes_expected = "<select id=\"bu_filter_pages\" name=\"post_parent\" class=\"test_class\">\r" .
@@ -1723,7 +1917,10 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 				"\n\t<option value=\"" . $parent . "\" >Parent Page</option>\r" .
 				"\r</select>\r";
 
-		$args = array( 'echo' => 0, 'select_classes' => 'test_class' );
+		$args                     = array(
+			'echo'           => 0,
+			'select_classes' => 'test_class',
+		);
 		$dropdown_classes_results = bu_navigation_page_parent_dropdown( $post_types, 0, $args );
 
 		$this->assertEquals( $dropdown_classes_expected, $dropdown_classes_results );
@@ -1734,15 +1931,15 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 	 * Covers bu_filter_pages_parent_dropdown()
 	 */
 	public function test_bu_filter_pages_parent_dropdown() {
-		$parent = $this->posts['parent'];
-		$child = $this->posts['child'];
+		$parent         = $this->posts['parent'];
+		$child          = $this->posts['child'];
 		$grandchild_one = $this->posts['grandchild_one'];
 
-		$pages = bu_navigation_get_pages();
-		$pages_by_parent = bu_navigation_pages_by_parent($pages);
+		$pages           = bu_navigation_get_pages();
+		$pages_by_parent = bu_navigation_pages_by_parent( $pages );
 
 		$page_options_expected = "\n\t" . '<option value="' . $child . '" >Child Page</option>' . "\r" .
-			"\n\t" . '<option value="' . $grandchild_one .  '" >&nbsp;&nbsp;&nbsp;Grand Child Page 1</option>' . "\r";
+			"\n\t" . '<option value="' . $grandchild_one . '" >&nbsp;&nbsp;&nbsp;Grand Child Page 1</option>' . "\r";
 
 		ob_start();
 		bu_filter_pages_parent_dropdown( $pages_by_parent, 0, $parent );
@@ -1752,11 +1949,11 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		$this->assertEquals( $page_options_results, $page_options_expected );
 
 		/**
-		* 	Test Default Function
+		*   Test Default Function
 		*/
 
 		$page_options_default_expected = "\n\t" . '<option value="' . $child . '" selected="selected">Child Page</option>' . "\r" .
-			"\n\t" . '<option value="' . $grandchild_one .  '" >&nbsp;&nbsp;&nbsp;Grand Child Page 1</option>' . "\r";
+			"\n\t" . '<option value="' . $grandchild_one . '" >&nbsp;&nbsp;&nbsp;Grand Child Page 1</option>' . "\r";
 
 		ob_start();
 		bu_filter_pages_parent_dropdown( $pages_by_parent, $child, $parent );
@@ -1766,10 +1963,10 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		$this->assertEquals( $page_options_default_expected, $page_options_default_results );
 
 		/**
-		* 	Test Parent Function
+		*   Test Parent Function
 		*/
 
-		$page_options_parent_expected = "\n\t" . '<option value="' . $grandchild_one .  '" >Grand Child Page 1</option>' . "\r";
+		$page_options_parent_expected = "\n\t" . '<option value="' . $grandchild_one . '" >Grand Child Page 1</option>' . "\r";
 
 		ob_start();
 		bu_filter_pages_parent_dropdown( $pages_by_parent, 0, $child );
@@ -1779,11 +1976,11 @@ class Test_BU_Navigation_Library extends BU_Navigation_UnitTestCase {
 		$this->assertEquals( $page_options_parent_expected, $page_options_parent_results );
 
 		/**
-		* 	Test Level Function
+		*   Test Level Function
 		*/
 
 		$page_options_level_expected = "\n\t" . '<option value="' . $child . '" selected="selected">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Child Page</option>' . "\r" .
-			"\n\t" . '<option value="' . $grandchild_one .  '" >&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Grand Child Page 1</option>' . "\r";
+			"\n\t" . '<option value="' . $grandchild_one . '" >&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Grand Child Page 1</option>' . "\r";
 
 		ob_start();
 		bu_filter_pages_parent_dropdown( $pages_by_parent, $child, $parent, 2 );

--- a/tests/phpunit/test-plugin.php
+++ b/tests/phpunit/test-plugin.php
@@ -8,7 +8,7 @@
  */
 class Test_BU_Navigation_Plugin extends BU_Navigation_UnitTestCase {
 
-	public function setUp(){
+	public function setUp() {
 		parent::setUp();
 
 		$this->plugin->load_widget();
@@ -21,7 +21,7 @@ class Test_BU_Navigation_Plugin extends BU_Navigation_UnitTestCase {
 
 		$features = $this->plugin->features();
 
-		foreach( $features as $feature => $default ) {
+		foreach ( $features as $feature => $default ) {
 
 			$this->assertEquals( $default, $this->plugin->supports( $feature ) );
 
@@ -44,7 +44,7 @@ class Test_BU_Navigation_Plugin extends BU_Navigation_UnitTestCase {
 
 		$features = $this->plugin->features();
 
-		foreach( $features as $feature => $default ) {
+		foreach ( $features as $feature => $default ) {
 
 			$this->assertEquals( $default, $this->plugin->supports( $feature ) );
 
@@ -55,24 +55,52 @@ class Test_BU_Navigation_Plugin extends BU_Navigation_UnitTestCase {
 
 	}
 
-	public function test_widget_adaptive_with_section_title(){
-		global $wp_widget_factory,
-		       $post;
+	public function test_widget_adaptive_with_section_title() {
+		global $wp_widget_factory, $post;
 
 		/**
 		 * IA
 		 * - Page 1
-	 	 *     - Subpage 1.A
-	 	 *         - Subpage 1.A.1 (widget loaded here)
-	 	 *             - Subpage 1.A.1.A (excluded from nav)
-	 	 *         - Subpage 1.A.2
+		 *     - Subpage 1.A
+		 *         - Subpage 1.A.1 (widget loaded here)
+		 *             - Subpage 1.A.1.A (excluded from nav)
+		 *         - Subpage 1.A.2
 		 */
 
-		$page1 = $this->factory->post->create( array( 'post_type' => 'page', 'post_title' => 'Page 1', ) );
-		$page1_A = $this->factory->post->create( array( 'post_type' => 'page', 'post_title' => 'Subpage 1-A', 'post_parent' => $page1 ) );
-		$page1_A_1 = $this->factory->post->create( array( 'post_type' => 'page', 'post_title' => 'Subpage 1-A-1 (Has Child)', 'post_parent' => $page1_A ) );
-		$page1_A_1_A = $this->factory->post->create( array( 'post_type' => 'page', 'post_title' => 'Subpage 1-A-1-A', 'post_parent' => $page1_A_1 ) );
-		$page1_A_2 = $this->factory->post->create( array( 'post_type' => 'page', 'post_title' => 'Subpage 1-A-2 (No Child)', 'post_parent' => $page1_A ) );
+		$page1       = $this->factory->post->create(
+			array(
+				'post_type'  => 'page',
+				'post_title' => 'Page 1',
+			)
+		);
+		$page1_A     = $this->factory->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_title'  => 'Subpage 1-A',
+				'post_parent' => $page1,
+			)
+		);
+		$page1_A_1   = $this->factory->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_title'  => 'Subpage 1-A-1 (Has Child)',
+				'post_parent' => $page1_A,
+			)
+		);
+		$page1_A_1_A = $this->factory->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_title'  => 'Subpage 1-A-1-A',
+				'post_parent' => $page1_A_1,
+			)
+		);
+		$page1_A_2   = $this->factory->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_title'  => 'Subpage 1-A-2 (No Child)',
+				'post_parent' => $page1_A,
+			)
+		);
 
 		// make sure we've got everyone
 		$posts = bu_navigation_get_posts();
@@ -90,37 +118,37 @@ class Test_BU_Navigation_Plugin extends BU_Navigation_UnitTestCase {
 		setup_postdata( $post );
 
 		$instance = array(
-			'navigation_title' => 'section',
+			'navigation_title'      => 'section',
 			'navigation_title_text' => '',
-			'navigation_title_url' => '',
-			'navigation_style' => 'adaptive',
-			);
+			'navigation_title_url'  => '',
+			'navigation_style'      => 'adaptive',
+		);
 
 		ob_start();
 		the_widget( 'BU_Widget_Pages', $instance );
 		$widget = ob_get_contents();
 		ob_end_clean();
 
-		$this->assertRegExp('/<h2.+Page 1<\/a>/i', $widget);
-		$this->assertRegExp('/class="level_1".+Subpage 1-A<\/a>/is', $widget);
+		$this->assertRegExp( '/<h2.+Page 1<\/a>/i', $widget );
+		$this->assertRegExp( '/class="level_1".+Subpage 1-A<\/a>/is', $widget );
 
 		// load perspective of page page1_A
 		$post = get_post( $page1_A );
 		setup_postdata( $post );
 
 		$instance = array(
-			'navigation_title' => 'section',
+			'navigation_title'      => 'section',
 			'navigation_title_text' => '',
-			'navigation_title_url' => '',
-			'navigation_style' => 'adaptive',
-			);
+			'navigation_title_url'  => '',
+			'navigation_style'      => 'adaptive',
+		);
 
 		ob_start();
 		the_widget( 'BU_Widget_Pages', $instance );
 		$widget = ob_get_contents();
 		ob_end_clean();
 
-		$this->assertRegExp('/<h2.+Page 1<\/a>/i', $widget);
-		$this->assertRegExp('/class="level_1".+Subpage 1-A<\/a>/is', $widget);
+		$this->assertRegExp( '/<h2.+Page 1<\/a>/i', $widget );
+		$this->assertRegExp( '/class="level_1".+Subpage 1-A<\/a>/is', $widget );
 	}
 }

--- a/tests/phpunit/test-reorder-tracker.php
+++ b/tests/phpunit/test-reorder-tracker.php
@@ -24,28 +24,28 @@ class Test_BU_Navigation_Reorder_Tracker extends BU_Navigation_UnitTestCase {
 
 	public function test_construct() {
 
-		$tracker = new BU_Navigation_Reorder_Tracker('page');
+		$tracker = new BU_Navigation_Reorder_Tracker( 'page' );
 
-		$this->assertInternalType('array', $tracker->post_types);
-		$this->assertContains('page',$tracker->post_types);
-		$this->assertContains('bu_link',$tracker->post_types);
+		$this->assertInternalType( 'array', $tracker->post_types );
+		$this->assertContains( 'page', $tracker->post_types );
+		$this->assertContains( 'bu_link', $tracker->post_types );
 
 	}
 
 	public function test_mark_post_as_moved() {
 
-		$post = get_post( $this->posts['child'] );
-		$post->post_parent = $this->posts['edit'];	// new parent
+		$post              = get_post( $this->posts['child'] );
+		$post->post_parent = $this->posts['edit'];  // new parent
 
-		$tracker = new BU_Navigation_Reorder_Tracker('page');
+		$tracker = new BU_Navigation_Reorder_Tracker( 'page' );
 		$tracker->mark_post_as_moved( $post );
 
 		$this->assertInternalType( 'array', $tracker->already_moved );
 		$this->assertArrayHasKey( $post->post_parent, $tracker->already_moved );
-		$this->assertArrayHasKey( 'ids', $tracker->already_moved[$post->post_parent] );
-		$this->assertArrayHasKey( 'positions', $tracker->already_moved[$post->post_parent] );
-		$this->assertContains( $post->ID, $tracker->already_moved[$post->post_parent]['ids'] );
-		$this->assertContains( $post->menu_order, $tracker->already_moved[$post->post_parent]['positions'] );
+		$this->assertArrayHasKey( 'ids', $tracker->already_moved[ $post->post_parent ] );
+		$this->assertArrayHasKey( 'positions', $tracker->already_moved[ $post->post_parent ] );
+		$this->assertContains( $post->ID, $tracker->already_moved[ $post->post_parent ]['ids'] );
+		$this->assertContains( $post->menu_order, $tracker->already_moved[ $post->post_parent ]['positions'] );
 
 	}
 
@@ -54,19 +54,19 @@ class Test_BU_Navigation_Reorder_Tracker extends BU_Navigation_UnitTestCase {
 
 		$post = get_post( $this->posts['parent'] );
 
-		$tracker = new BU_Navigation_Reorder_Tracker('page');
+		$tracker = new BU_Navigation_Reorder_Tracker( 'page' );
 		$tracker->mark_section_for_reordering( $post->ID );
 
 		$this->assertInternalType( 'array', $tracker->already_moved );
 		$this->assertArrayHasKey( $post->ID, $tracker->already_moved );
-		$this->assertArrayHasKey( 'ids', $tracker->already_moved[$post->ID] );
-		$this->assertArrayHasKey( 'positions', $tracker->already_moved[$post->ID] );
+		$this->assertArrayHasKey( 'ids', $tracker->already_moved[ $post->ID ] );
+		$this->assertArrayHasKey( 'positions', $tracker->already_moved[ $post->ID ] );
 
 	}
 
 	public function test_post_already_moved() {
 
-		$tracker = new BU_Navigation_Reorder_Tracker('page');
+		$tracker = new BU_Navigation_Reorder_Tracker( 'page' );
 
 		// Check against post that has not moved
 		$parent = get_post( $this->posts['parent'] );
@@ -75,7 +75,13 @@ class Test_BU_Navigation_Reorder_Tracker extends BU_Navigation_UnitTestCase {
 
 		// Check against post that has moved
 		$post = get_post( $this->posts['child'] );
-		wp_update_post(array('ID'=>$post->ID,'post_parent'=>$this->posts['edit'],'menu_order'=>1));
+		wp_update_post(
+			array(
+				'ID'          => $post->ID,
+				'post_parent' => $this->posts['edit'],
+				'menu_order'  => 1,
+			)
+		);
 		$moved = get_post( $this->posts['child'] );
 		$tracker->mark_post_as_moved( $moved );
 
@@ -86,11 +92,16 @@ class Test_BU_Navigation_Reorder_Tracker extends BU_Navigation_UnitTestCase {
 
 	public function test_position_already_set() {
 
-		$tracker = new BU_Navigation_Reorder_Tracker('page');
+		$tracker = new BU_Navigation_Reorder_Tracker( 'page' );
 
 		// Check against post that has moved
 		$post = get_post( $this->posts['grandchild_one'] );
-		wp_update_post(array('ID'=>$post->ID,'menu_order'=>2));
+		wp_update_post(
+			array(
+				'ID'         => $post->ID,
+				'menu_order' => 2,
+			)
+		);
 		$moved = get_post( $this->posts['grandchild_one'] );
 
 		$tracker->mark_post_as_moved( $moved );
@@ -102,13 +113,18 @@ class Test_BU_Navigation_Reorder_Tracker extends BU_Navigation_UnitTestCase {
 
 	public function test_has_moves() {
 
-		$tracker = new BU_Navigation_Reorder_Tracker('page');
+		$tracker = new BU_Navigation_Reorder_Tracker( 'page' );
 
 		$this->assertFalse( $tracker->has_moves() );
 
 		// Check against post that has moved
 		$post = get_post( $this->posts['grandchild_one'] );
-		wp_update_post(array('ID'=>$post->ID,'menu_order'=>2));
+		wp_update_post(
+			array(
+				'ID'         => $post->ID,
+				'menu_order' => 2,
+			)
+		);
 		$moved = get_post( $this->posts['grandchild_one'] );
 		$tracker->mark_post_as_moved( $moved );
 
@@ -122,49 +138,66 @@ class Test_BU_Navigation_Reorder_Tracker extends BU_Navigation_UnitTestCase {
 	public function test_run() {
 
 		// Before state:
-		$this->assertEquals( $this->posts['parent'], get_post($this->posts['child'])->post_parent );
-		$this->assertEquals( $this->posts['child'], get_post($this->posts['grandchild_one'])->post_parent );
-		$this->assertEquals( 1, get_post($this->posts['grandchild_one'])->menu_order );
-		$this->assertEquals( 2, get_post($this->posts['grandchild_two'])->menu_order );
+		$this->assertEquals( $this->posts['parent'], get_post( $this->posts['child'] )->post_parent );
+		$this->assertEquals( $this->posts['child'], get_post( $this->posts['grandchild_one'] )->post_parent );
+		$this->assertEquals( 1, get_post( $this->posts['grandchild_one'] )->menu_order );
+		$this->assertEquals( 2, get_post( $this->posts['grandchild_two'] )->menu_order );
 
-		$this->assertEquals( 0, get_post($this->posts['hidden'])->post_parent );
-		$this->assertEquals( 1, get_post($this->posts['parent'])->menu_order );
-		$this->assertEquals( 2, get_post($this->posts['hidden'])->menu_order );
-		$this->assertEquals( 3, get_post($this->posts['edit'])->menu_order );
-		$this->assertEquals( 4, get_post($this->posts['private'])->menu_order );
-		$this->assertEquals( 5, get_post($this->posts['google'])->menu_order );
-		$this->assertEquals( 6, get_post($this->posts['last_page'])->menu_order );
+		$this->assertEquals( 0, get_post( $this->posts['hidden'] )->post_parent );
+		$this->assertEquals( 1, get_post( $this->posts['parent'] )->menu_order );
+		$this->assertEquals( 2, get_post( $this->posts['hidden'] )->menu_order );
+		$this->assertEquals( 3, get_post( $this->posts['edit'] )->menu_order );
+		$this->assertEquals( 4, get_post( $this->posts['private'] )->menu_order );
+		$this->assertEquals( 5, get_post( $this->posts['google'] )->menu_order );
+		$this->assertEquals( 6, get_post( $this->posts['last_page'] )->menu_order );
 
-		$tracker = new BU_Navigation_Reorder_Tracker('page');
+		$tracker = new BU_Navigation_Reorder_Tracker( 'page' );
 
-		wp_update_post(array('ID'=>$this->posts['hidden'],'post_parent'=>$this->posts['child'],'menu_order'=>1));
-		wp_update_post(array('ID'=>$this->posts['child'],'post_parent'=>0,'menu_order'=>1));
-		wp_delete_post($this->posts['grandchild_two'], true);
-		wp_update_post(array('ID'=>$this->posts['private'],'menu_order'=>5));
+		wp_update_post(
+			array(
+				'ID'          => $this->posts['hidden'],
+				'post_parent' => $this->posts['child'],
+				'menu_order'  => 1,
+			)
+		);
+		wp_update_post(
+			array(
+				'ID'          => $this->posts['child'],
+				'post_parent' => 0,
+				'menu_order'  => 1,
+			)
+		);
+		wp_delete_post( $this->posts['grandchild_two'], true );
+		wp_update_post(
+			array(
+				'ID'         => $this->posts['private'],
+				'menu_order' => 5,
+			)
+		);
 
-		$move_one = get_post($this->posts['hidden']);
-		$move_two = get_post($this->posts['child']);
-		$move_three = get_post($this->posts['private']);
+		$move_one   = get_post( $this->posts['hidden'] );
+		$move_two   = get_post( $this->posts['child'] );
+		$move_three = get_post( $this->posts['private'] );
 
 		// Mark two posts as moved, reorder section that contained deleted child
-		$tracker->mark_post_as_moved($move_one);
-		$tracker->mark_post_as_moved($move_two);
-		$tracker->mark_post_as_moved($move_three);
+		$tracker->mark_post_as_moved( $move_one );
+		$tracker->mark_post_as_moved( $move_two );
+		$tracker->mark_post_as_moved( $move_three );
 		$tracker->mark_section_for_reordering( $this->posts['child'] );
 
 		// Perform reordering
 		$tracker->run();
 
-		$this->assertEquals( $this->posts['child'], get_post($this->posts['hidden'])->post_parent );
-		$this->assertEquals( 1, get_post($this->posts['hidden'])->menu_order );
-		$this->assertEquals( 2, get_post($this->posts['grandchild_one'])->menu_order );
-		$this->assertEquals( 0, get_post($this->posts['child'])->post_parent );
-		$this->assertEquals( 1, get_post($this->posts['child'])->menu_order );
-		$this->assertEquals( 2, get_post($this->posts['parent'])->menu_order );
-		$this->assertEquals( 3, get_post($this->posts['edit'])->menu_order );
-		$this->assertEquals( 4, get_post($this->posts['google'])->menu_order );
-		$this->assertEquals( 5, get_post($this->posts['private'])->menu_order );
-		$this->assertEquals( 6, get_post($this->posts['last_page'])->menu_order );
+		$this->assertEquals( $this->posts['child'], get_post( $this->posts['hidden'] )->post_parent );
+		$this->assertEquals( 1, get_post( $this->posts['hidden'] )->menu_order );
+		$this->assertEquals( 2, get_post( $this->posts['grandchild_one'] )->menu_order );
+		$this->assertEquals( 0, get_post( $this->posts['child'] )->post_parent );
+		$this->assertEquals( 1, get_post( $this->posts['child'] )->menu_order );
+		$this->assertEquals( 2, get_post( $this->posts['parent'] )->menu_order );
+		$this->assertEquals( 3, get_post( $this->posts['edit'] )->menu_order );
+		$this->assertEquals( 4, get_post( $this->posts['google'] )->menu_order );
+		$this->assertEquals( 5, get_post( $this->posts['private'] )->menu_order );
+		$this->assertEquals( 6, get_post( $this->posts['last_page'] )->menu_order );
 
 	}
 

--- a/tests/phpunit/test-settings.php
+++ b/tests/phpunit/test-settings.php
@@ -22,12 +22,12 @@ class Test_BU_Navigation_Settings extends BU_Navigation_UnitTestCase {
 	public function test_get_all() {
 
 		$expected_settings = array(
-			'display' => true,
+			'display'   => true,
 			'max_items' => BU_NAVIGATION_PRIMARY_MAX,
-			'dive' => true,
-			'depth' => BU_NAVIGATION_PRIMARY_DEPTH,
-			'allow_top' => true
-			);
+			'dive'      => true,
+			'depth'     => BU_NAVIGATION_PRIMARY_DEPTH,
+			'allow_top' => true,
+		);
 
 		$this->assertSame( $expected_settings, $this->plugin->settings->get_all() );
 
@@ -36,12 +36,12 @@ class Test_BU_Navigation_Settings extends BU_Navigation_UnitTestCase {
 	public function test_update() {
 
 		$updates = array(
-			'display' => false,
+			'display'   => false,
 			'max_items' => 3,
-			'dive' => false,
-			'depth' => 2,
-			'allow_top' => false
-			);
+			'dive'      => false,
+			'depth'     => 2,
+			'allow_top' => false,
+		);
 
 		$this->plugin->settings->update( $updates );
 		$this->plugin->settings->clear();


### PR DESCRIPTION
No functional code changes, this just applies basic phpcbf automatic formatting changes to the phpunit test code.

No active code is affected, just the unit tests.

I ran some step-debugging on the reformatted test code didn't see any functional differences.