### PR TITLE
Adds block dynamic preview through Rest API endpoint

### DIFF
--- a/src/block.php
+++ b/src/block.php
@@ -35,10 +35,35 @@ function get_only_parents() {
 }
 
 /**
+ * Returns block markup for editing preview
+ *
+ * Takes block attributes as parameters and returns the current markup output.
+ * Used for block preview.
+ *
+ * @param WP_REST_Request $data Parameters from the rest request.
+ * @return string Rendered block markup.
+ */
+function block_markup( $data ) {
+
+	if ( ! $data['id'] ) {
+		// Bail early if there's no valid id.
+		return rest_ensure_response( 'provide post id' );
+	}
+
+	$attributes = [
+		'rootPostID' => $data['id'],
+		'navMode'    => 'section', //need to also get this thru api param
+	];
+	return rest_ensure_response( navigation_block_render_callback( $attributes ) );
+
+}
+
+/**
  * Add REST endpoint for parents query.
  */
 add_action(
 	'rest_api_init', function() {
+		// Endpoint for parent posts.
 		register_rest_route(
 			'bu-navigation/v1', '/parents/', array(
 				'methods'             => 'GET',
@@ -47,6 +72,17 @@ add_action(
 					return current_user_can( 'edit_others_posts' );
 				},
 			)
+		);
+
+		// Endpoint for block preview.
+		register_rest_route(
+			'bu-navigation/v1', '/markup/(?P<id>[\d]+)', [
+				'methods'             => 'GET',
+				'callback'            => __NAMESPACE__ . '\block_markup',
+				'permission_callback' => function () {
+					return current_user_can( 'edit_others_posts' );
+				},
+			]
 		);
 	}
 );

--- a/src/block.php
+++ b/src/block.php
@@ -139,7 +139,6 @@ function navigation_block_init() {
 
 	register_block_type(
 		'bu-navigation/navigation-block', array(
-			'api_version'     => 2,
 			'editor_script'   => 'bu-navigation-block',
 			'editor_style'    => 'bu-navigation-block-editor-style',
 			'render_callback' => __NAMESPACE__ . '\navigation_block_render_callback',

--- a/src/block.php
+++ b/src/block.php
@@ -45,14 +45,14 @@ function get_only_parents() {
  */
 function block_markup( $data ) {
 
-	if ( ! $data['id'] ) {
-		// Bail early if there's no valid id.
-		return rest_ensure_response( 'provide post id' );
+	if ( ! $data['id'] || ! $data['navMode'] ) {
+		// Bail early if attributes are missing.
+		return rest_ensure_response( 'No valid navigation items' );
 	}
 
 	$attributes = [
 		'rootPostID' => $data['id'],
-		'navMode'    => 'section', //need to also get this thru api param
+		'navMode'    => $data['navMode'],
 	];
 	return rest_ensure_response( navigation_block_render_callback( $attributes ) );
 
@@ -76,7 +76,7 @@ add_action(
 
 		// Endpoint for block preview.
 		register_rest_route(
-			'bu-navigation/v1', '/markup/(?P<id>[\d]+)', [
+			'bu-navigation/v1', '/markup', [
 				'methods'             => 'GET',
 				'callback'            => __NAMESPACE__ . '\block_markup',
 				'permission_callback' => function () {

--- a/src/edit.js
+++ b/src/edit.js
@@ -22,6 +22,9 @@ export default function Edit( { attributes, setAttributes } ) {
 		{ postid: 0, title: '', type: '' },
 	] );
 
+	const [ preview, setPreview ] = useState( '' );
+
+	// Load all parent posts for the block's rootPostID attribute.
 	useEffect( () => {
 		getParents();
 	}, [] );
@@ -31,6 +34,18 @@ export default function Edit( { attributes, setAttributes } ) {
 			path: 'bu-navigation/v1/parents',
 		} );
 		setParents( fetchedParents );
+	};
+
+	// Refresh the block preview markup whenever the attributes change.
+	useEffect( () => {
+		getPreview();
+	}, [ attributes ] );
+
+	const getPreview = async () => {
+		const fetchedPreview = await apiFetch( {
+			path: `bu-navigation/v1/markup/${ attributes.rootPostID }`,
+		} );
+		setPreview( fetchedPreview );
 	};
 
 	return (
@@ -67,6 +82,7 @@ export default function Edit( { attributes, setAttributes } ) {
 				] }
 				onChange={ ( option ) => setAttributes( { navMode: option } ) }
 			/>
+			<div dangerouslySetInnerHTML={ { __html: preview } } />
 		</div>
 	);
 }

--- a/src/edit.js
+++ b/src/edit.js
@@ -43,7 +43,7 @@ export default function Edit( { attributes, setAttributes } ) {
 
 	const getPreview = async () => {
 		const fetchedPreview = await apiFetch( {
-			path: `bu-navigation/v1/markup/${ attributes.rootPostID }`,
+			path: `bu-navigation/v1/markup?id=${ attributes.rootPostID }&navMode=${ attributes.navMode }`,
 		} );
 		setPreview( fetchedPreview );
 	};

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,6 @@ import Edit from './edit';
  * @see https://developer.wordpress.org/block-editor/developers/block-api/#registering-a-block
  */
 registerBlockType( 'bu-navigation/navigation-block', {
-	apiVersion: 2,
 	title: 'Navigation Block',
 	icon: 'admin-site-alt3',
 	category: 'widgets',


### PR DESCRIPTION
Even though it is available, the [Block Editor Handbook](https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/creating-dynamic-blocks/) recommends against using `<ServerSideRender>` for dynamic block previews:

```Server-side render is meant as a fallback; client-side rendering in JavaScript is always preferred (client rendering is faster and allows better editor manipulation).```

To accomplish client rendering, this PR adds:
- An API endpoint that will return the block markup for given attributes.
- A `useEffect` hook in the block editor that fetches and renders the block markup when the attributes change.

(It also removes the block api v2 declaration, since we are targeting WP 5.4 compatibility.)