### PR TITLE
Make navigation tree section cache persistent

### DIFF
--- a/bu-navigation.php
+++ b/bu-navigation.php
@@ -5,7 +5,7 @@
  * Author: Boston University (IS&T)
  * Author URI: http://sites.bu.edu/web/
  * Description: Provides alternative navigation elements designed for blogs with large page counts
- * Version: 1.3.5
+ * Version: 1.3.6
  * Text Domain: bu-navigation
  * Domain Path: /languages
  * License: GPL2+
@@ -94,7 +94,7 @@ class BU_Navigation_Plugin {
 	 *
 	 * @var string
 	 */
-	const VERSION = '1.3.4';
+	const VERSION = '1.3.6';
 
 	/**
 	 * Plugin class constructor.
@@ -124,17 +124,29 @@ class BU_Navigation_Plugin {
 	}
 
 	/**
-	 * Calls wp_cache_add_non_persistent_groups()
+	 * Object cache group configuration for the navigation tree.
 	 *
-	 * Calling wp_cache_add_non_persistent_groups() doesn't appear to do anything
-	 * in modern WordPress?
+	 * The 'bu-navigation' group caches the section/membership structure built by
+	 * load_sections() (see composer-includes/bu-navigation-core-widget/src/data-model.php).
+	 * It is intentionally left PERSISTENT (Redis-backed in production) rather than
+	 * registered non-persistent.
+	 *
+	 * This is safe by construction: the cached payload is order- and status-independent
+	 * parent->children membership only, and its cache key is version-stamped on core's
+	 * 'posts' last_changed value (bumped by clean_post_cache() on every post
+	 * insert/update/delete), so a stale entry is orphaned rather than served. Publication
+	 * status, menu_order ordering, and nav meta are all applied downstream on the uncached
+	 * get_nav_posts() query, so they are never served from this cache.
+	 *
+	 * Previously this method registered the group non-persistent. On production (where an
+	 * object cache is active) that defeated cross-request caching, forcing the expensive
+	 * GROUP_CONCAT/GROUP BY wp_posts scan to run on nearly every front-end render under
+	 * crawler concurrency. Leaving the group persistent removes that scan from the common
+	 * case while preserving the existing per-request invalidation behavior.
 	 *
 	 * @return void
 	 */
 	public function add_cache_groups() {
-		if ( function_exists( 'wp_cache_add_non_persistent_groups' ) ) {
-			wp_cache_add_non_persistent_groups( array( 'bu-navigation' ) );
-		}
 	}
 
 	/**

--- a/composer-includes/bu-navigation-core-widget/src/data-model.php
+++ b/composer-includes/bu-navigation-core-widget/src/data-model.php
@@ -87,7 +87,11 @@ function load_sections( $post_types = array( 'page' ), $include_links = true ) {
 		wp_cache_set( 'last_changed', $last_changed, 'posts' );
 	}
 
-	$cache_key = 'all_sections:' . md5( serialize( $post_types ) . ":$last_changed" );
+	// Scope the key to the current site. The 'bu-navigation' group is Redis-backed
+	// (persistent) in production, and although the object cache prefixes non-global
+	// group keys by blog, including the blog id here guarantees per-site isolation on
+	// multisite regardless of the drop-in's behavior.
+	$cache_key = 'all_sections:' . get_current_blog_id() . ':' . md5( serialize( $post_types ) . ":$last_changed" );
 	if ( $all_sections = wp_cache_get( $cache_key, 'bu-navigation' ) ) {
 		return $all_sections;
 	}
@@ -105,8 +109,10 @@ function load_sections( $post_types = array( 'page' ), $include_links = true ) {
 
 	$all_sections = transform_rows( $rows );
 
-	// Cache results.
-	wp_cache_set( $cache_key, $all_sections, 'bu-navigation' );
+	// Cache results. The version-stamped key (posts 'last_changed') is the primary
+	// invalidation; the explicit TTL is a self-healing backstop in case a membership
+	// change ever bypasses clean_post_cache() (e.g. a direct $wpdb write or import).
+	wp_cache_set( $cache_key, $all_sections, 'bu-navigation', DAY_IN_SECONDS );
 
 	return $all_sections;
 }

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 **Tags:** navigation, hierarchical, post type, boston university, bu
 **Requires at least:** 3.1
 **Tested up to:** 5.7
-**Stable tag:** 1.3.5
+**Stable tag:** 1.3.6
 **License:** GPLv2 or later
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -114,6 +114,15 @@ Please see this page for the details:
 ![The same drag and drop view is available to move pages while editing them](https://ps.w.org/bu-navigation/assets/screenshot-5.png)
 
 ## Changelog
+
+### 1.3.6
+
+* Makes the navigation tree section cache (`load_sections`) persistent instead of
+  non-persistent, so the page-hierarchy `GROUP_CONCAT` query is reused across requests
+  rather than re-run on nearly every front-end render. The cache key is site-scoped and
+  version-stamped on the core posts cache, with a one-day TTL backstop; publication status,
+  ordering, and navigation meta continue to be applied on the uncached posts query, so
+  navigation output is unchanged.
 
 ### 1.3.4
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: ntk, mgburns, gcorne, jtwiest, awbauer, inderpreet99
 Tags: navigation, hierarchical, post type, boston university, bu
 Requires at least: 3.1
 Tested up to: 5.7
-Stable tag: 1.3.5
+Stable tag: 1.3.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -78,6 +78,10 @@ Please see this page for the details:
 5. The same drag and drop view is available to move pages while editing them
 
 == Changelog ==
+
+= 1.3.6 =
+
+* Makes the navigation tree section cache (`load_sections`) persistent instead of non-persistent, so the page-hierarchy `GROUP_CONCAT` query is reused across requests rather than re-run on nearly every front-end render. The cache key is site-scoped and version-stamped on the core posts cache, with a one-day TTL backstop; publication status, ordering, and navigation meta continue to be applied on the uncached posts query, so navigation output is unchanged.
 
 = 1.3.4 =
 


### PR DESCRIPTION
The 'bu-navigation' object cache group (the load_sections section/membership structure) was registered non-persistent, so on production with an active object cache the expensive GROUP_CONCAT/GROUP BY wp_posts scan re-ran on nearly every front-end render under crawler concurrency.

Leave the group persistent (Redis-backed). This is safe by construction: the cached payload is order- and status-independent parent/children membership only, keyed on core's posts 'last_changed' value (bumped by clean_post_cache() on every post insert/update/delete), so a stale entry is orphaned rather than served. Publication status, menu_order ordering, and navigation meta are applied downstream on the uncached get_nav_posts() query and are never served from this cache.

Harden the cache entry with an explicit DAY_IN_SECONDS TTL backstop and a site-scoped key (get_current_blog_id()) for multisite isolation, mirroring the bu-calendar default-URL cache.

Bump version to 1.3.6; also corrects the VERSION constant, which had drifted to 1.3.4 while the plugin header read 1.3.5.